### PR TITLE
Fast interactions

### DIFF
--- a/src/mapinteractions.jl
+++ b/src/mapinteractions.jl
@@ -1,39 +1,80 @@
-mapinteraction!(multidata::MultiSimData, interaction::Interaction) = begin
+
+mapinteraction!(multidata::MultiSimData, rule::Interaction) = begin
     nrows, ncols = framesize(multidata)
-     
+
     # Only pass in the data that the interaction wants, in that order
-    interactiondata = map(key -> multidata[key], keys(interaction))
+    interactiondata = map(key -> multidata[key], keys(rule))
 
     for j in 1:ncols, i in 1:nrows
         ismasked(multidata, i, j) && continue
-        state = map(d -> source(d)[i, j], interactiondata) 
-        newstate = applyinteraction(interaction, interactiondata, state, (i, j))
+        state = map(d -> source(d)[i, j], interactiondata)
+        newstate = applyinteraction(rule, interactiondata, state, (i, j))
         map(interactiondata, newstate) do d, s
             @inbounds dest(d)[i, j] = s
         end
     end
 end
 
-mapinteraction!(multidata::MultiSimData, interaction::PartialInteraction) = begin
-    nrows, ncols = framesize(multidata)
-
+mapinteraction!(multidata::MultiSimData, rule::PartialInteraction) = begin
     # Copy the sources to dests
-    map(data(multidata)) do d 
+    map(data(multidata)) do d
         @inbounds parent(dest(d)) .= parent(source(d))
     end
-     
-    # Only pass in the data that the interaction wants, in that order
-    keys_ = keys(interaction)
-    interactiondata = @set multidata.data = 
-        NamedTuple{keys_}(map(key -> WritableSimData(multidata[key]), keys_))
 
-    # Loop manually. TODO: use blockrun?
-    for j in 1:ncols, i in 1:nrows
-        ismasked(multidata, i, j) && continue
-        state = map(d -> source(d)[i, j], data(interactiondata)) 
-        applyinteraction!(interaction, interactiondata, state, (i, j))
-    end
+    # Only pass in the data that the rule wants, in that order
+    wkeys, wdata = writedata(rule, multidata)
+    rkeys, rdata = readdata(rule, multidata)
+    simdata = @set multidata.data = ruledata(wkeys, wdata)
+    _interactionloop(rule, simdata, rdata, mask(multidata))
 
-    map(d -> updatestatus!(sourcestatus(d), deststatus(d)), data(interactiondata))
+    # Update status of all arrays written to
+    copystatus!(wdata)
 end
 
+_interactionloop(rule, simdata, readdata, mask) = begin
+    nrows, ncols = framesize(data(simdata)[1])
+    for j in 1:ncols, i in 1:nrows
+        ismasked(mask, i, j) && continue
+        state = readstate(readdata, i, j)
+        applyinteraction!(rule, simdata, state, (i, j))
+    end
+end
+
+@inline readstate(data::Tuple, I...) = map(d -> readstate(d, I...), data)
+@inline readstate(data, I...) = data[I...] 
+
+copystatus!(data::Tuple{Vararg{<:AbstractSimData}}) = map(copystatus!, data)
+copystatus!(data::AbstractSimData) =
+    copystatus!(sourcestatus(data), deststatus(data))
+copystatus!(srcstatus::AbstractArray, deststatus::AbstractArray) = srcstatus .= deststatus
+copystatus!(srcstatus, deststatus) = nothing
+
+@inline ruledata(key, data) = ruledata((key,), (data,))
+@inline ruledata(keys::Tuple{Vararg{<:Val}}, data::Tuple) = 
+    NamedTuple{map(_keyval, keys)}(data)
+
+@inline _keyval(keys::Val{K}) where K = K
+
+writedata(rule::Interaction, multidata) = writedata(writekeys(rule), multidata)
+@inline writedata(keys::Tuple{Symbol,Vararg}, multidata) =
+    writedata(map(Val, keys), multidata)
+@inline writedata(key::Symbol, multidata) = writedata(Val(key), multidata)
+writedata(keys::Tuple{Val,Vararg}, multidata) = begin
+    k, d = writedata(keys[1], multidata)
+    ks, ds = writedata(tail(keys), multidata)
+    (k, ks...), (d, ds...)
+end
+writedata(keys::Tuple{}, multidata) = (), ()
+writedata(key::Val{K}, multidata) where K = key, WritableSimData(multidata[K])
+
+readdata(rule::Interaction, multidata) = readdata(readkeys(rule), multidata)
+@inline readdata(keys::Tuple{Symbol,Vararg}, multidata) =
+    readdata(map(Val, keys), multidata)
+@inline readdata(key::Symbol, multidata) = readdata(Val(key), multidata)
+readdata(keys::Tuple{Val,Vararg}, multidata) = begin
+    k, d = readdata(keys[1], multidata)
+    ks, ds = readdata(tail(keys), multidata)
+    (k, ks...), (d, ds...)
+end
+readdata(keys::Tuple{}, multidata) = (), ()
+readdata(key::Val{K}, multidata) where K = key, multidata[K]

--- a/src/maprules.jl
+++ b/src/maprules.jl
@@ -78,7 +78,7 @@ maprule!(data::AbstractSimData, rule::PartialRule) = begin
     @inbounds parent(dest(data)) .= parent(source(data))
     # Run the rule for active blocks
     blockrun!(data, rule)
-    updatestatus!(sourcestatus(data), deststatus(data))
+    copystatus!(data)
 end
 
 @inline celldo!(data::WritableSimData, rule::PartialRule, I) = begin
@@ -248,7 +248,7 @@ maprule!(data::SingleSimData{T,2}, rule::Union{NeighborhoodRule,Chain{<:Tuple{Ne
             end
         end
     end
-    updatestatus!(sourcestatus(data), deststatus(data))
+    copystatus!(data)
 end
 
 """
@@ -304,7 +304,3 @@ handleoverflow!(data, overflow::RemoveOverflow, r) = nothing
 
 combinestatus(x::Number, y::Number) = x + y
 combinestatus(x::Integer, y::Integer) = x | y
-
-updatestatus!(copyto, copyfrom) = nothing
-updatestatus!(copyto::AbstractArray, copyfrom::AbstractArray) =
-    @inbounds copyto .= copyfrom

--- a/src/outputs/graphic.jl
+++ b/src/outputs/graphic.jl
@@ -82,7 +82,7 @@ showgrid(o::GraphicOutput, f=lastindex(o), t=stoptime(o)) =
     showgrid(o[f], o, f, t)
 # Get frame f from output and call showgrid again
 showgrid(o::GraphicOutput, data::AbstractSimData, f, t) =
-    showgrid(o[gridindex(o, f)], o, data, f, t)
+    showgrid(o[frameindex(o, f)], o, data, f, t)
 # Handle a vector of SimData from replicate sims
 showgrid(o::GraphicOutput, data::AbstractVector{<:AbstractSimData}, f, t) =
     showgrid(o, data[1], f, t)

--- a/src/outputs/output.jl
+++ b/src/outputs/output.jl
@@ -73,8 +73,8 @@ zerogrids(init::NamedTuple, nframes) =
     [map(layer -> zero(layer), init) for f in 1:nframes]
 
 
-@inline celldo!(data::SimData, frame::AbstractArray, index, f) =
-    return @inbounds frame[index...] = data[index...]
+@inline celldo!(data::SimData, ouputgrid::AbstractArray, index, f) =
+    return @inbounds ouputgrid[index...] = data[index...]
 
 storegrid!(output::Output, data) = storegrid!(output, data, frameindex(output, data))
 storegrid!(output::Output, data::SimData, f) = begin
@@ -83,15 +83,12 @@ storegrid!(output::Output, data::SimData, f) = begin
 end
 storegrid!(output::Output, multidata::MultiSimData, f) = begin
     checkbounds(output, f)
-    map(_storegrid!, values(output[f]), values(data(multidata)))
-end
-
-_storegrid!(outputgrid::AbstractArray, sourcegrid::SimData) = begin
-    for i in CartesianIndices(outputgrid)
-        outputgrid[i] = sourcegrid[i]
+    map(values(output[f]), values(data(multidata))) do outputgrid, data
+        for i in CartesianIndices(outputgrid)
+            outputgrid[i] = data[i]
+        end
     end
 end
-
 # Replicated frames
 storegrid!(output, data::AbstractVector{<:SimData}, f) = begin
     for j in 1:size(output[1], 2), i in 1:size(output[1], 1)

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -43,7 +43,6 @@ Ruleset(rules::Vararg{<:Rule}; kwargs...) = Ruleset(; rules=rules, kwargs...)
 Ruleset(args...; kwargs...) = Ruleset(; rules=args, kwargs...)
 rules(rs::Ruleset) = rs.rules
 
-# Getters
 
 show(io::IO, ruleset::Ruleset) = begin
     printstyled(io, Base.nameof(typeof(ruleset)), " =\n"; color=:blue)
@@ -88,10 +87,3 @@ standardise_ruleset(ruleset, mask, overflow, cellsize, timestep) = begin
     @set! ruleset.timestep = timestep
     ruleset
 end
-
-
-
-# struct HasMinMax end
-# struct NoMinMax end
-
-# hasminmax(ruleset::T) where T = fieldtype(T, :minval) <: Number ? HasMinMax() : NoMinMax()

--- a/src/simulationdata.jl
+++ b/src/simulationdata.jl
@@ -212,7 +212,9 @@ end
 Initialise the block status array.
 This tracks whether anything has to be done in an area of the main array.
 """
-updatestatus!(data) = updatestatus!(parent(source(data)), sourcestatus(data), deststatus(data), radius(data))
+updatestatus!(data::Tuple) = map(updatestatus!, data) 
+updatestatus!(data::AbstractSimData) = 
+    updatestatus!(parent(source(data)), sourcestatus(data), deststatus(data), radius(data))
 updatestatus!(source, sourcestatus::Bool, deststatus::Bool, r) = nothing
 updatestatus!(source, sourcestatus, deststatus, r) = begin
     blocksize = 2r

--- a/src/simulationdata.jl
+++ b/src/simulationdata.jl
@@ -203,10 +203,18 @@ addpadding(init::AbstractArray{T,N}, r) where {T,N} = begin
     source .= zero(eltype(source))
     # Copy the init array to he middle section of the source array
     for j in 1:size(init, 2), i in 1:size(init, 1)
-        source[i, j] = init[i, j]
+        @inbounds source[i, j] = init[i, j]
     end
     source
 end
+
+"""
+Copy status from one array to another, allowing
+for doing nothing if they are not both arrays.
+"""
+copystatus!(copyto, copyfrom) = nothing
+copystatus!(copyto::AbstractArray, copyfrom::AbstractArray) =
+    @inbounds copyto .= copyfrom
 
 """
 Initialise the block status array.
@@ -229,6 +237,11 @@ updatestatus!(source, sourcestatus, deststatus, r) = begin
     end
 end
 
+copystatus!(data::Tuple{Vararg{<:AbstractSimData}}) = map(copystatus!, data)
+copystatus!(data::AbstractSimData) =
+    copystatus!(sourcestatus(data), deststatus(data))
+copystatus!(srcstatus::AbstractArray, deststatus::AbstractArray) = srcstatus .= deststatus
+copystatus!(srcstatus, deststatus) = nothing
 
 """
 When no simdata is passed in, the existing SimData arrays are re-initialised

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -51,6 +51,6 @@ ruletypes(ts::Type{<:Tuple}) = (ruletypes.(ts.parameters)...,)
 """
 Check if a cell is masked, using the passed-in mask grid.
 """
-@inline ismasked(data::AbstractSimData, i...) = ismasked(mask(data), i...)
-@inline ismasked(mask::Nothing, i...) = false
-@inline ismasked(mask::AbstractArray, i...) = @inbounds return !mask[i...]
+@inline ismasked(data::AbstractSimData, I...) = ismasked(mask(data), I...)
+@inline ismasked(mask::Nothing, I...) = false
+@inline ismasked(mask::AbstractArray, I...) = @inbounds return !(mask[I...])

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,5 +1,5 @@
 using DynamicGrids, Test, Colors, ColorSchemes, FieldDefaults
-using DynamicGrids: normalisegrid, grid2image, @Image, @Graphic, @Output
+using DynamicGrids: grid2image, @Image, @Graphic, @Output, minval, maxval, normalise
 using ColorSchemes: leonardo
 
 init = [8.0 10.0;
@@ -13,7 +13,7 @@ output = TestImageOutput(init, minval=0.0, maxval=10.0)
 ruleset = Ruleset(Life())
 
 # Test level normalisation
-normed = normalisegrid(output, output[1])
+normed = normalise.(output[1], minval(output), maxval(output))
 @test normed == [0.8 1.0
                  0.0 0.5]
 

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -58,19 +58,19 @@ struct TestPartialNeighborhoodRule{N} <: PartialNeighborhoodRule
     neighborhood::N
 end
 
-struct TestNeighborhoodInteraction{Keys,N} <: NeighborhoodInteraction{Keys}
+struct TestNeighborhoodInteraction{W,R,N} <: NeighborhoodInteraction{W,R}
     neighborhood::N
 end
 
-struct TestPartialNeighborhoodInteraction{Keys,N} <: PartialNeighborhoodInteraction{Keys}
+struct TestPartialNeighborhoodInteraction{W,R,N} <: PartialNeighborhoodInteraction{W,R}
     neighborhood::N
 end
 
 @testset "radius" begin
     rulesetA = Ruleset(TestNeighborhoodRule(RadialNeighborhood{1}()))
     rulesetB = Ruleset(TestPartialNeighborhoodRule(RadialNeighborhood{5}()))
-    interactionA = TestPartialNeighborhoodInteraction{(:a,),RadialNeighborhood{3}}(RadialNeighborhood{3}())
-    interactionB = TestPartialNeighborhoodInteraction{(:b,),RadialNeighborhood{2}}(RadialNeighborhood{2}())
+    interactionA = TestNeighborhoodInteraction{:a,:a,RadialNeighborhood{3}}(RadialNeighborhood{3}())
+    interactionB = TestPartialNeighborhoodInteraction{Tuple{:b},Tuple{:b},RadialNeighborhood{2}}(RadialNeighborhood{2}())
     multiruleset = MultiRuleset(
         rulesets = (a = rulesetA, b=rulesetB),
         interactions = (interactionA, interactionB)

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -1,5 +1,5 @@
 using DynamicGrids, Test
-using DynamicGrids: isshowable, allocategrids!, gridindex, storegrid!, SimData
+using DynamicGrids: isshowable, allocategrids!, frameindex, storegrid!, SimData
 
 init = [10.0 11.0;
         0.0   5.0]
@@ -7,7 +7,7 @@ init = [10.0 11.0;
 output = ArrayOutput(init)
 ruleset = Ruleset(Life())
 
-@test gridindex(output, 5) == 5 
+@test frameindex(output, 5) == 5 
 @test isshowable(output, 5) == false
 
 # Test pushing new frames to an output


### PR DESCRIPTION
improve interaction performance by
- making everything type stable
- reducing array reads by separating read and write grids. this also makes the interaction definition syntax better and opens up ore optimisations later, like interaction chaining.