### PR TITLE
Better init

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "DynamicGrids"
 uuid = "a5dba43e-3abc-5203-bfc5-584ca68d3f5b"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.8.1"
+version = "0.9.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FieldDefaults = "49426c49-986f-5969-8844-d5cc96441cfc"
 FieldDocTables = "a5d692f0-33f0-11e9-293e-eb83c8d6177d"
@@ -26,6 +27,7 @@ julia = "1.2, 1.3, 1.4, 1.5"
 Colors = "0.9, 0.10, 0.11, 0.12"
 ConstructionBase = "1"
 Crayons = "4"
+DimensionalData = "^0.10.7"
 DocStringExtensions = "0.8"
 FieldDefaults = "0.3"
 FieldDocTables = "0.1"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ running the included game of life model `Life()`:
 using DynamicGrids, Crayons
 
 init = rand(Bool, 150, 200)
-output = REPLOutput(init; fps=30, color=Crayon(foreground=:red, background=:black, bold=true))
-ruleset = Ruleset(Life(); init=init)
-sim!(output, ruleset; tspan=(1, 200))
+output = REPLOutput(init; tspan=1:200, fps=30, color=Crayon(foreground=:red, background=:black, bold=true))
+sim!(output, Life())
 ```
 
 ![REPL life](https://github.com/cesaraustralia/DynamicGrids.jl/blob/media/life.gif?raw=true)
@@ -43,21 +42,22 @@ specific `applyrule` method that operates on each of the active cells in the gri
 Rules come in a number of flavours (outlined in the 
 [docs](https://cesaraustralia.github.io/DynamicGrids.jl/stable/#Rules-1)), which allow
 assumptions to be made about running them that can greatly improve performance.
-Rules are joined in a `Ruleset` object and run in sequence:
+Rules are added to a `Ruleset`, with some additional parameters:
 
 ```
-ruleset = Ruleset(Life(2, 3))
+ruleset = Ruleset(Life(2, 3); opt=SparseOpt())
 ```
 
-The `Ruleset` wrapper seems a little redundant here, but multiple models can be
-combined in a `Ruleset`. Each rule will be run for the whole grid, in sequence,
-using appropriate optimisations depending on the parent types of each rule:
+Multiple models can be combined in a `Ruleset`. Each rule will be run for the
+whole grid, in sequence, using appropriate optimisations depending on the parent
+types of each rule:
 
 ```julia
-ruleset = Ruleset(rule1, rule2)
+ruleset = Ruleset(rule1, rule2; timestep=Day(1), opt=SparseOpt())
 ```
 
-For better performance (often ~2x), models included in a `Chain` object will be
+
+For better performance (often ~2x or more), models included in a `Chain` object will be
 combined into a single model, using only one array read and write. This
 optimisation is limited to `CellRule`, or a `NeighborhoodRule`
 followed by `CellRule`. If the `@inline` compiler macro is used on all
@@ -68,16 +68,15 @@ efficient function call.
 ruleset = Ruleset(rule1, Chain(rule2, rule3, rule4))
 ```
 
-A `Ruleset` can also hold rules that act on multiple grids. These may
-either run side by side independently (say for live comparative analysis), or
-interact.
+A `Ruleset` can hold rules that act on multiple grids. These may either run side
+by side independently (say for live comparative analysis), or may interact.
 
 
 ## Init
 
-The init array may be any AbstractArray or a NamedTuple of AbstractArray, 
+`init` may be any `AbstractArray` or a `NamedTuple` of `AbstractArray`, 
 It contains whatever initialisation data is required to start the simulation. 
-The array type, size and element type of the init array determine the types
+The array type, size and element type of the `init` object determine the types
 used in the simulation, as well as providing the initial conditions:
 
 ```juli
@@ -96,7 +95,7 @@ or passed into a simulation, where it will take preference over the `Ruleset` in
 sim!(output, rulset; init=init)
 ```
 
-For multiple grids, init is a NamedTuple of equal-sized arrays
+For multiple grids, `init` is a `NamedTuple` of equal-sized arrays
 matching the names given to each `Ruleset` :
 
 ```julia
@@ -125,14 +124,14 @@ initialised with the init array, but in this case it also requires the number
 of simulation frames to preallocate before the simulation runs.
 
 ```julia
-output = ArrayOutput(init, 10)
+output = ArrayOutput(init; tspan=1:10)
 ```
 
 The `REPLOutput` shown above is an inbuilt `GraphicOutput` that can be useful for checking a
 simulation when working in a terminal or over ssh:
 
 ```julia
-output = REPLOutput(init)
+output = REPLOutput(init; tspan=1:100)
 ```
 
 `ImageOutput` is the most complex class of outputs, allowing full color visual
@@ -183,29 +182,16 @@ end
 # Set up the init array, ruleset and output (using a Gtk window)
 init = fill(ALIVE, 400, 400)
 processor = ColorProcessor(scheme=ColorSchemes.rainbow, zerocolor=RGB24(0.0))
-output = GtkOutput(init; fps=25, minval=DEAD, maxval=BURNING, processor=processor)
+output = GtkOutput(init; tspan=1:200, fps=25, minval=DEAD, maxval=BURNING, processor=processor)
 
 # Run the simulation
-sim!(output, rule; init=init, tspan=(1, 200))
+sim!(output, rule)
 
 # Save the output as a gif
 savegif("forestfire.gif", output)
 ```
 
 ![forestfire](https://user-images.githubusercontent.com/2534009/72052469-5450c580-3319-11ea-8948-5196d1c6fd33.gif)
-
-
-
-We could also use a "windy" custom neighborhood:
-
-```julia
-windyhood = CustomNeighborhood((1,1), (1,2), (1,3), (2,1), (3,1))
-ruleset = Ruleset(ForestFire(; neighborhood=windyhood); init=init)
-sim!(output, ruleset; tspan=(1, 200))
-savegif("windy_forestfire.gif", output)
-```
-
-![windy_forestfire](https://user-images.githubusercontent.com/2534009/72198637-a95d1a80-3484-11ea-8b77-25a4a94b3943.gif)
 
 
 Timing the simulation for 200 steps, the performance is quite good:
@@ -228,8 +214,8 @@ using DynamicGridsInteract, FieldMetadata
 import FieldMetadata: @bounds, bounds, @description, description
 
 @bounds @description :($(typeof(rule.f)) begin
-  prob_combustion | (0.0, 0.01) | "Probability the cell will spontaneously combust"
-  prob_regrowth   | (0.0, 0.1)  | "Probability the cell will grow back"
+    prob_combustion | (0.0, 0.01) | "Probability the cell will spontaneously combust"
+    prob_regrowth   | (0.0, 0.1)  | "Probability the cell will grow back"
 end
 
 output = InteractOutput(init, rule; fps=25, minval=DEAD, maxval=BURNING, processor=processor)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ rule = let prob_combustion=0.0001, prob_regrowth=0.01
     end
 end
 
-# Set up the init array, ruleset and output (using a Gtk window)
+# Set up the init array and output (using a Gtk window)
 init = fill(ALIVE, 400, 400)
 processor = ColorProcessor(scheme=ColorSchemes.rainbow, zerocolor=RGB24(0.0))
 output = GtkOutput(init; tspan=1:200, fps=25, minval=DEAD, maxval=BURNING, processor=processor)
@@ -197,8 +197,8 @@ savegif("forestfire.gif", output)
 Timing the simulation for 200 steps, the performance is quite good:
 
 ```julia
-output = ArrayOutput(init, 200)
-@time sim!(output, ruleset; tspan=(1, 200))
+output = ArrayOutput(init; tspan=1:200)
+@time sim!(output, ruleset)
  1.384755 seconds (640 allocations: 2.569 MiB)
 
 # To save a gif of the ArrayOutput we need to pass in a processor and the min and max
@@ -206,22 +206,6 @@ output = ArrayOutput(init, 200)
 
 savegif("forestfire.gif", output; minval=DEAD, maxval=BURNING, processor=processor)
 ```
-
-We can also tweak the parameters while the simulation runs in atom:
-
-```julia
-using DynamicGridsInteract, FieldMetadata
-import FieldMetadata: @bounds, bounds, @description, description
-
-@bounds @description :($(typeof(rule.f)) begin
-    prob_combustion | (0.0, 0.01) | "Probability the cell will spontaneously combust"
-    prob_regrowth   | (0.0, 0.1)  | "Probability the cell will grow back"
-end
-
-output = InteractOutput(init, rule; fps=25, minval=DEAD, maxval=BURNING, processor=processor)
-display(output)
-```
-
 
 ## Alternatives
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
 using Documenter, DynamicGrids
-using DynamicGrids: @Output, @Graphic, @Image, applyrule, applyrule!,
-      setneighbor!, mapsetneighbor!, neighbors, sumneighbors,
+using DynamicGrids: applyrule, applyrule!, setneighbor!, mapsetneighbor!, neighbors, sumneighbors,
       AbstractSimData, SimData, GridData, ReadableGridData, WritableGridData
 
 makedocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,26 +21,26 @@ init = round.(Int8, max.(0.0, rand(-2.0:0.1:1.0, 70,70)))
 model = Ruleset(Life())
 
 # Use an output that shows the cellular automata as blocks in the REPL
-output = REPLOutput(init; fps=5)
+output = REPLOutput(init; tspan=1:50, fps=5)
 
-sim!(output, model; init=init, tspan=(1, 50))
+sim!(output, model)
 ```
 
 More life-like examples:
 
 ```julia
 # Morley
-sim!(output, Ruleset(Life(b=[3,6,8], s=[2,4,5]); init=init))
+sim!(output, Ruleset(Life(b=[3,6,8], s=[2,4,5]))
 
 # 2x2
-sim!(output, Ruleset(Life(b=[3,6], s=[1,2,5]); init=init))
+sim!(output, Ruleset(Life(b=[3,6], s=[1,2,5])))
 
 # Dimoeba
 init1 = round.(Int8, max.(0.0, rand(70,70)))
 sim!(output, Ruleset(Life(b=[3,5,6,7,8], s=[5,6,7,8]); init=init1))
 
 ## No death
-sim!(output, Ruleset(Life(b=[3], s=[0,1,2,3,4,5,6,7,8]); init))
+sim!(output, Ruleset(Life(b=[3], s=[0,1,2,3,4,5,6,7,8])))
 
 ## 34 life
 sim!(output, Ruleset(Life(b=[3,4], s=[3,4])); init=init, fps=10)
@@ -63,13 +63,15 @@ any number of grids.
 ```@docs
 Ruleset
 Rule
-CellRule
-NeighborhoodRule
-ManualRule
-ManualNeighborhoodRule
-Map          
 Chain
+CellRule
+Cell
+NeighborhoodRule
+Neighbors
 Life
+ManualRule
+Manual
+ManualNeighborhoodRule
 ```
 
 ```@docs
@@ -79,7 +81,7 @@ applyrule!
 
 ## Neighborhoods
 
-Neighborhoods define a pattern of cells surrounding the current cell, 
+Neighborhoods define a pattern of cells surrounding the current cell,
 and how they are combined to update the value of the current cell.
 
 ```@docs
@@ -111,26 +113,17 @@ REPLOutput
 ImageOutput
 ```
 
-
-Dynamic grids uses [Mixers.jl](https://github.com/rafaqz/Mixers.jl) mixins
-to simplify specifying custom outputs with the required fields.
-
-```@docs
-@Output
-@Graphic
-@Image
-```
-
 ### Grid processors
 
 ```@docs
 GridProcessor
-SingleGridProcessor 
+SingleGridProcessor
 ColorProcessor
 MultiGridProcessor
 ThreeColorProcessor
 LayoutProcessor
 Greyscale
+Grayscale
 ```
 
 ### Gifs
@@ -139,13 +132,24 @@ Greyscale
 savegif
 ```
 
-## Overflow
+## Ruleset config
+
+### Overflow
 
 ```@docs
 Overflow
 WrapOverflow
 RemoveOverflow
 ```
+
+### Optimisation
+
+```@docs
+PerformanceOpt
+NoOpt
+SparseOpt
+```
+
 
 ## Internal data handling
 

--- a/src/DynamicGrids.jl
+++ b/src/DynamicGrids.jl
@@ -38,7 +38,7 @@ import FieldMetadata: @description, description,
 
 
 
-export sim!, resume!, replay, savegif, isinferred, neighbors, rules
+export sim!, resume!, replay, savegif, isinferred, neighbors, rules, method, methodtype
 
 export Rule, NeighborhoodRule, CellRule, ManualRule, ManualNeighborhoodRule
 
@@ -79,6 +79,7 @@ const FIELDDOCTABLE = FieldDocTable((:Description, :Default, :Bounds),
 
 include("rules.jl")
 include("rulesets.jl")
+include("extent.jl")
 include("simulationdata.jl")
 include("chain.jl")
 include("neighborhoods.jl")
@@ -91,6 +92,7 @@ include("interface.jl")
 include("framework.jl")
 include("sequencerules.jl")
 include("maprules.jl")
+include("overflow.jl")
 include("utils.jl")
 include("map.jl")
 include("life.jl")

--- a/src/DynamicGrids.jl
+++ b/src/DynamicGrids.jl
@@ -12,6 +12,7 @@ end DynamicGrids
 using Colors,
       ConstructionBase,
       Crayons,
+      DimensionalData,
       DocStringExtensions,
       FieldDefaults,
       FieldMetadata,
@@ -37,7 +38,7 @@ import FieldMetadata: @description, description,
 
 
 
-export sim!, resume!, replay, savegif, isinferred, neighbors
+export sim!, resume!, replay, savegif, isinferred, neighbors, rules
 
 export Rule, NeighborhoodRule, CellRule, ManualRule, ManualNeighborhoodRule
 

--- a/src/extent.jl
+++ b/src/extent.jl
@@ -1,0 +1,31 @@
+
+"""
+    Extent(init, mask, tspan, aux) 
+    Extent(; init, mask=nothing, tspan, aux=nothing, kwargs...) 
+
+Container for extensive variables: spatial and timeseries data.
+These are kept separate from rules to allow application
+of rules to alternate spatial and temporal contexts.
+
+Not usually constructed directly by users, but it can be passed to outputs
+instead of `init`, `mask`, `tspan` and `aux`.
+"""
+mutable struct Extent{I,M,A}
+    init::I
+    mask::M
+    tspan::AbstractRange
+    aux::A
+end
+Extent(; init, mask=nothing, tspan, aux=nothing, kwargs...) = 
+    Extent(init, mask, tspan, aux) 
+
+init(e::Extent) = e.init
+mask(e::Extent) = e.mask
+tspan(e::Extent) = e.tspan
+aux(e::Extent) = e.aux
+
+settspan!(e::Extent, tspan) = e.tspan = tspan
+setstarttime!(e::Extent, start) =
+    e.tspan = start:step(tspan(e)):last(tspan(e))
+setstoptime!(e::Extent, stop) =
+    e.tspan = first(tspan(e)):step(tspan(e)):stop

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -1,8 +1,10 @@
 
 """
     sim!(output, [ruleset=ruleset(output)];
-         init=init(ruleset),
+         init=init(output),
+         mask=mask(output),
          tstpan=tspan(output),
+         aux=aux(output),
          fps=fps(output),
          simdata=nothing,
          nreplicates=nothing)
@@ -12,67 +14,67 @@ the passed in output for each time-step.
 
 ### Arguments
 - `output`: An [`Output`](@ref) to store grids or display them on the screen.
-- `ruleset`: A [`Ruleset`](@ref) containing one ore more [`Rule`](@ref)s.
-  These will each be run in sequence.
+- `ruleset`: A [`Ruleset`](@ref) containing one ore more [`Rule`](@ref)s. If the output
+  has a `Ruleset` attached, it will be used.
 
 ### Keyword Arguments
-- `init`: the initialisation array. If not passed, the [`Ruleset`](@ref) must contain an `init` array.
+
+Theses are the taken from the output argument by default.
+
+- `init`: optional array or NamedTuple of arrays.
+- `mask`: a `Bool` array matching the init array size. `false` cells do not run.
+- `aux`: a `NamedTuple` of auxilary data to be used by rules.
 - `tspan`: a tuple holding the start and end of the timespan the simulaiton will run for.
-  Taken from the output length if not passed in.
 - `fps`: the frames per second to display. Will be taken from the output if not passed in.
 - `nreplicates`: the number of replicates to combine in stochastic simulations
 - `simdata`: a [`SimData`](@ref) object. Keeping it between simulations can reduce memory
   allocation when that is important.
 """
 sim!(output::Output, ruleset=ruleset(output);
-     init=init(output), 
-     tspan=tspan(output), 
-     fps=fps(output), 
-     nreplicates=nothing, 
+     init=init(output),
+     mask=mask(output),
+     tspan=tspan(output),
+     aux=aux(output),
+     fps=fps(output),
+     nreplicates=nothing,
      simdata=nothing) = begin
 
     # Some rules are only valid for a set time-step size.
     step(ruleset) !== nothing && step(ruleset) != step(tspan) &&
         throw(ArgumentError("tspan step $(step(tspan)) must equal rule step $(step(ruleset))"))
 
+    # Rebuild Extent to allow kwarg alterations
+    extent = Extent(asnamedtuple(init), mask, tspan, aux)
+    # Set up output
     initialise(output)
     isrunning(output) && error("A simulation is already running in this output")
     setrunning!(output, true) || error("Could not start the simulation with this output")
     setstarttime!(output, first(tspan))
-    # Copy the init array from the ruleset or keyword arg
-    simdata = initdata!(simdata, init, mask(output), ruleset, tspan, nreplicates)
+    # Create or update the combined data object for the simulation
+    simdata = initdata!(simdata, extent, ruleset, nreplicates)
     # Delete grids output by the previous simulations
     initgrids!(output, init)
+    # Set run speed for GraphicOutputs
     setfps!(output, fps)
     # Show the first grid
     showgrid(output, simdata, 1, tspan)
     # Let the init grid be displayed as long as a normal grid
     delay(output, 1)
-    # Run the simulation
+    # Run the simulation over simdata and a unitrange
     runsim!(output, simdata, 1:lastindex(tspan))
 end
 
 """
-    sim!(output, rules...; init, kwargs...)
+    sim!(output, rules...; kwargs...)
 
 Shorthand for running a rule without defining a `Ruleset`.
-
-You must pass in the `init` `Array` of `NamedTuple`, and if the `tspan` is not 
-simply a `Tuple` or `AbstractRange` of `Int`, it must be passed in as a range 
-in order to know the timestep.
 """
-sim!(output::Output, rules::Rule...; 
-     tspan=tspan(output), 
-     overflow=RemoveOverflow(), 
-     opt=SparseOpt(), 
-     mask=nothing,
-     init=init(output),
-     cellsize=1,
+sim!(output::Output, rules::Rule...;
+     tspan=tspan(output),
+     overflow=RemoveOverflow(),
      kwargs...) = begin
-    ruleset = Ruleset(rules...; 
-        timestep=step(tspan), cellsize=cellsize, opt=opt, overflow=overflow
-    )
-    sim!(output::Output, ruleset; tspan=tspan, init=init)
+    ruleset = Ruleset(rules...; timestep=step(tspan), kwargs...)
+    sim!(output::Output, ruleset; tspan=tspan, kwargs...)
 end
 
 """
@@ -82,9 +84,8 @@ end
             simdata=nothing,
             nreplicates=nothing)
 
-Restart the simulation where you stopped last time. For arguments see [`sim!`](@ref).
-The keyword arg `tadd` indicates the number of grid frames to add, and of course an init
-array will not be accepted.
+Restart the simulation from where you stopped last time. For arguments see [`sim!`](@ref).
+The keyword arg `stop` can be used to extend the length of the simulation.
 
 ### Arguments
 - `output`: An [`Output`](@ref) to store grids or display them on the screen.
@@ -92,25 +93,29 @@ array will not be accepted.
   These will each be run in sequence.
 
 ### Keyword Arguments (optional
-- `init`: the initialisation array. If not passed, the [`Ruleset`](@ref) must contain
-  an `init` array.
-- `tstop`: the stop time for the simulation. Taken from the output length if not passed in.
-- `fps`: the frames per second to display. Taken from the output if not passed in.
+- `init`: an optional initialisation array
+- `tstop`: the new stop time for the simulation. Taken from the output length by default.
+- `fps`: the frames per second to display. Taken from the output by default.
 - `nreplicates`: the number of replicates to combine in stochastic simulations
-- `simdata`: a [`SimData`](@ref) object. Keeping it between simulations can reduce memory
-  allocation when that is important.
+- `simdata`: a [`SimData`](@ref) object. Keeping it between simulations can improve performance
+  when that is important
 """
 resume!(output::Output, ruleset::Ruleset=ruleset(output);
-        tstop=stoptime(output), fps=fps(output),
-        simdata=nothing, nreplicates=nothing) = begin
+        tstop=stoptime(output),
+        fps=fps(output),
+        simdata=nothing,
+        nreplicates=nothing) = begin
+    # Initialise
     initialise(output)
+    # Check status and arguments
     length(output) > 0 || error("There is no simulation to resume. Run `sim!` first")
     isrunning(output) && error("A simulation is already running in this output")
     setrunning!(output, true) || error("Could not start the simulation with this output")
-    lastframe = lastindex(tspan(output))
-    newtspan = tspan(output)[1]:step(tspan(output)):tstop
-    stopframe = lastindex(newtspan)
 
+    # Calculate new timespan
+    lastframe = lastindex(tspan(output))
+    new_tspan = tspan(output)[1]:step(tspan(output)):tstop
+    stopframe = lastindex(new_tspan)
     fspan = lastframe:stopframe
     setstoptime!(output, tstop)
     # Use the last frame of the existing simulation as the init frame
@@ -119,8 +124,10 @@ resume!(output::Output, ruleset::Ruleset=ruleset(output);
     else
         init = first(output)
     end
-    simdata = initdata!(simdata, init, mask(output), ruleset, newtspan, nreplicates)
+
     setfps!(output, fps)
+    extent = Extent(asnamedtuple(init), mask(output), new_tspan, aux(output))
+    simdata = initdata!(simdata, extent, ruleset, nreplicates)
     runsim!(output, simdata, fspan)
 end
 
@@ -157,18 +164,18 @@ simloop!(output::Output, simdata, fspan) = begin
         # Exit gracefully
         if !isrunning(output) || f == last(fspan)
             showgrid(output, simdata, f, currenttime(simdata))
-            setrunning!(output, false)
             setstoptime!(output, currenttime(simdata))
             finalise(output)
             break
         end
     end
+    setrunning!(output, false)
     output
 end
 
 # We have to keep the original rulset as it may be modified elsewhere
 # like in an Interact.jl interface. `Ruleset` is mutable.
-precalcrules!(simdata::Vector{<:SimData}) = precalcrules!.(simdata) 
+precalcrules!(simdata::Vector{<:SimData}) = precalcrules!.(simdata)
 precalcrules!(simdata::SimData) = begin
     simdata.ruleset.rules = precalcrules(rules(simdata), simdata)
     simdata

--- a/src/map.jl
+++ b/src/map.jl
@@ -28,7 +28,7 @@ rule = let y = y
 end
 ```
 """
-@description @flattenable struct Cell{R,W,F} <: CellRule{R,W}
+@flattenable @description struct Cell{R,W,F} <: CellRule{R,W}
     # Field | Flatten | Description
     f::F    | true    | "Function to apply to the read values"
 end
@@ -64,7 +64,7 @@ rule = let x = 10
 end
 ```
 """
-@description @flattenable struct Neighbors{R,W,F,N} <: NeighborhoodRule{R,W}
+@flattenable @description struct Neighbors{R,W,F,N} <: NeighborhoodRule{R,W}
     # Field         | Flatten | Description
     f::F            | true    | "Function to apply to the neighborhood and read values"
     neighborhood::N | true    | ""
@@ -95,7 +95,8 @@ rule = let x = 10
 end
 ```
 """
-@description @flattenable struct Manual{R,W,F} <: ManualRule{R,W}
+@flattenable @description struct Manual{R,W,F} <: ManualRule{R,W}
+    # Field | Flatten | Description
     f::F    | true    | "Function to apply to the data, index and read values"
 end
 Manual(f; read=:_default_, write=read) = Manual{read,write}(f)

--- a/src/map.jl
+++ b/src/map.jl
@@ -52,7 +52,12 @@ A [`NeighborhoodRule`](@ref) that receives a neighbors object for the first
 `read` grid and the passed in neighborhood, followed by the cell values for 
 the reqquired grids, as with [`Cell`](@ref).
 
-Returned value(s) are written to the `write`/`W` grid.
+Returned value(s) are written to the `write`/`W` grid. 
+
+As with all NeighborhoodRule, you do not have to check bounds at grid edges, 
+that is handled for you by growing the grid to match the neighborhood radius.
+Using [`SparseOpt`](@ref) may imrove neighborhood performance when zero values
+are both common and can be safely ignored.
 
 ## Example
 
@@ -63,6 +68,7 @@ rule = let x = 10
     end
 end
 ```
+The `let` block greatly imroves performance.
 """
 @flattenable @description struct Neighbors{R,W,F,N} <: NeighborhoodRule{R,W}
     # Field         | Flatten | Description
@@ -94,6 +100,7 @@ rule = let x = 10
     end
 end
 ```
+The `let` block greatly imroves performance.
 """
 @flattenable @description struct Manual{R,W,F} <: ManualRule{R,W}
     # Field | Flatten | Description
@@ -105,3 +112,17 @@ Manual(f; read=:_default_, write=read) = Manual{read,write}(f)
     let data=data, index=index, rule=rule, read=astuple(rule, read)
         rule.f(data, index, read...)
     end
+
+"""
+    method(rule)
+
+Get the method of a `Cell`, `Neighbors`, or `Manual` rule.
+"""
+method(rule::Union{Cell,Neighbors,Manual}) = rule.f
+"""
+    methodtype(rule)
+
+Get the method type of a `Cell`, `Neighbors`, or `Manual` rule.
+This is useful in combination with FieldMetadata.jl macros.
+"""
+methodtype(rule::Union{Cell,Neighbors,Manual}) = typeof(method(rule))

--- a/src/maprules.jl
+++ b/src/maprules.jl
@@ -4,21 +4,21 @@ struct _Write_ end
 
 # Set up the rule data to loop over
 maprule!(simdata::SimData, rule::Rule) = begin
-    rkeys, rgrids = getdata(_Read_(), rule, simdata)
-    wkeys, wgrids = getdata(_Write_(), rule, simdata)
+    rkeys, rgrids = getgrids(_Read_(), rule, simdata)
+    wkeys, wgrids = getgrids(_Write_(), rule, simdata)
     # Copy the source to dest for grids we are writing to,
     # if they need to be copied
     _maybeupdate_dest!(wgrids, rule)
     # Combine read and write grids to a temporary simdata object
-    tempsimdata = @set simdata.data = combinedata(rkeys, rgrids, wkeys, wgrids)
+    tempsimdata = @set simdata.grids = combinegrids(rkeys, rgrids, wkeys, wgrids)
     # Run the rule loop
-    ruleloop(opt(simdata), rule, tempsimdata, rkeys, rgrids, wkeys, wgrids)
+    ruleloop(opt(simdata), rule, tempsimdata, rkeys, rgrids, wkeys, wgrids, mask(simdata))
     # Copy the source status to dest status for all write grids
     copystatus!(wgrids)
     # Swap the dest/source of grids that were written to
     wgrids = swapsource(wgrids) |> _to_readonly
     # Combine the written grids with the original simdata
-    replacedata(simdata, wkeys, wgrids)
+    replacegrids(simdata, wkeys, wgrids)
 end
 
 _to_readonly(data::Tuple) = map(ReadableGridData, data)
@@ -29,64 +29,106 @@ _maybeupdate_dest!(ds::Tuple, rule) =
 _maybeupdate_dest!(d::WritableGridData, rule::Rule) =
     handleoverflow!(d)
 _maybeupdate_dest!(d::WritableGridData, rule::ManualRule) = begin
-    @inbounds parent(dest(d)) .= parent(source(d))
+    copy!(parent(dest(d)), parent(source(d)))
     handleoverflow!(d)
 end
 
 # Separated out for both modularity and as a function barrier for type stability
 
-ruleloop(::PerformanceOpt, rule::Rule, simdata::SimData, rkeys, rgrids, wkeys, wgrids) = begin
-    nrows, ncols = gridsize(data(simdata)[1])
-
+ruleloop(::PerformanceOpt, rule::Rule, simdata::SimData, rkeys, rgrids, wkeys, wgrids, mask) = begin
+    nrows, ncols = gridsize(grids(simdata)[1])
     for j in 1:ncols, i in 1:nrows
-        ismasked(mask(simdata), i, j) && continue
+        ismasked(mask, i, j) && continue
         readval = readgrids(rkeys, rgrids, i, j)
         writeval = applyrule(rule, simdata, readval, (i, j))
         writegrids!(wgrids, writeval, i, j)
     end
 end
 
-ruleloop(::PerformanceOpt, rule::ManualRule, simdata::SimData, rkeys, rgrids, wkeys, wgrids) = begin
-    nrows, ncols = gridsize(data(simdata)[1])
+ruleloop(::PerformanceOpt, rule::ManualRule, simdata::SimData, rkeys, rgrids, wkeys, wgrids, mask) = begin
+    nrows, ncols = gridsize(grids(simdata)[1])
     for j in 1:ncols, i in 1:nrows
-        ismasked(mask(simdata), i, j) && continue
+        ismasked(mask, i, j) && continue
         readval = readgrids(rkeys, rgrids, i, j)
         applyrule!(rule, simdata, readval, (i, j))
     end
 end
-#= Run the rule for all cells, writing the result to the dest array
-The neighborhood is copied to the rules neighborhood buffer array for performance.
-Empty blocks are skipped for NeighborhoodRules. =#
-ruleloop(opt::NoOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:NeighborhoodRule,Vararg}}},
-         simdata::SimData, rkeys, rgrids, wkeys, wgrids) where {R,W} = begin
-    r = radius(rule)
+
+ruleloop(::SparseOpt, rule::ManualRule, simdata::SimData, rkey, rgrid::GridData, wkeys, wgrids, mask) =
+    let rule=rule, simdata=simdata, rkey=rkey, rgrid=rgrid
+        runsparse(rgrid) do i, j
+            ismasked(mask, i, j) && return
+            readval = readgrids(rkey, rgrid, i, j)
+            applyrule!(rule, simdata, readval, (i, j))
+            return
+        end
+    end
+
+#= runsparse Runs simulations over sparse blocks. Inactive blocks do not run.
+This can lead to order of magnitude performance improvments in sparse
+simulations where large areas of the grid are filled with zeros. =#
+runsparse(f, data::GridData) = begin
+    nrows, ncols = gridsize(data)
+    r = radius(data)
+    if r > 0
+        blocksize = 2r
+        status = sourcestatus(data)
+
+        for bj in 1:size(status, 2) - 1, bi in 1:size(status, 1) - 1
+            @inbounds status[bi, bj] || continue
+            # Convert from padded block to init dimensions
+            istart = blocktoind(bi, blocksize) - r
+            jstart = blocktoind(bj, blocksize) - r
+            # Stop at the init row/column size, not the padding or block multiple
+            istop = min(istart + blocksize - 1, nrows)
+            jstop = min(jstart + blocksize - 1, ncols)
+            # Skip the padding
+            istart = max(istart, 1)
+            jstart = max(jstart, 1)
+
+            for j in jstart:jstop, i in istart:istop
+                f(i, j)
+            end
+        end
+    else
+        for j in 1:ncols, i in 1:nrows
+            f(i, j)
+        end
+    end
+end
+
+ruleloop(opt::PerformanceOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:NeighborhoodRule,Vararg}}},
+         simdata::SimData, rkeys, rgrids, wkeys, wgrids, mask) where {R,W} = begin
     griddata = simdata[neighborhoodkey(rule)]
+    #= Blocks are cell smaller than the hood, because this works very nicely for
+    #looking at only 4 blocks at a time. Larger blocks mean each neighborhood is more
+    #likely to be active, smaller means handling more than 2 neighborhoods per block.
+    It would be good to test if this is the sweet spot for performance,
+    it probably isn't for game of life size grids. =#
+    r = radius(rule)
     blocksize = 2r
     hoodsize = 2r + 1
     nrows, ncols = gridsize(griddata)
     # We unwrap offset arrays and work with the underlying array
     src, dst = parent(source(griddata)), parent(dest(griddata))
-    blockrows, blockcols = indtoblock.(size(src), blocksize)
-    # curstatus and newstatus track active status for 4 local blocks
     # Get the preallocated neighborhood buffers
     # Center of the buffer for both axes
-    bufcenter = r + 1
     # Build multiple rules for each neighborhood buffer
-    bufrules = spreadbuffers(rule, init(griddata))
-    buffers = map(r -> buffer(neighborhood(r)), bufrules)
+    buffers, bufrules = spreadbuffers(rule, init(griddata))
+    ruleloop(opt, rule, simdata, rkeys, rgrids, wkeys, wgrids,
+             griddata, src, dst, buffers, bufrules, r, blocksize, hoodsize, nrows, ncols, mask)
+end
 
-    #= Run the rule row by row. When we move along a row by one cell, we access only
-    a single new column of data the same hight of the nighborhood, and move the existing
-    data in the neighborhood buffer array accross by one column. This saves on reads
-    from the main array, and focusses reads and writes in the small buffer array that
-    should be in fast local memory. =#
+ruleloop(opt::NoOpt, rule, simdata::SimData, rkeys, rgrids, wkeys, wgrids,
+         griddata, src, dst, buffers, bufrules, r, blocksize, hoodsize, nrows, ncols, mask
+         ) where {R,W} = begin
 
+    blockrows, blockcols = indtoblock.(size(src), blocksize)
     # Loop down a block COLUMN
     for bi = 1:blockrows
         rowsinblock = min(blocksize, nrows - blocksize * (bi - 1))
         # Get current block
         i = blocktoind(bi, blocksize)
-
 
         # Loop along the block ROW. This is faster because we are reading
         # 1 column from the main array for multiple blocks at each step,
@@ -95,13 +137,9 @@ ruleloop(opt::NoOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighborho
             # Which block column are we in
             if j == 1
                 # Reinitialise neighborhood buffers
-                for y = 1:hoodsize
-                    for b in 1:rowsinblock
-                        for x = 1:hoodsize
-                            val = src[i + b + x - 2, y]
-                            @inbounds buffers[b][x, y] = val
-                        end
-                    end
+                for y = 1:hoodsize, b = 1:rowsinblock, x = 1:hoodsize
+                    val = src[i + b + x - 2, y]
+                    @inbounds buffers[b][x, y] = val
                 end
             else
                 # Move the neighborhood buffers accross one column
@@ -120,16 +158,14 @@ ruleloop(opt::NoOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighborho
             end
 
             curblockj = indtoblock(j, blocksize)
-
             # Loop over the grid ROWS inside the block
             for b in 1:rowsinblock
                 I = i + b - 1, j
-                ismasked(simdata, I...) && continue
+                ismasked(mask, I...) && continue
                 # Which block row are we in
                 curblocki = b <= r ? 1 : 2
                 # Run the rule using buffer b
                 readval = readgrids(keys2vals(readkeys(rule)), rgrids, I...)
-                #read = buf[bufcenter, bufcenter]
                 writeval = applyrule(bufrules[b], simdata, readval, I)
                 writegrids!(wgrids, writeval, I...)
             end
@@ -137,38 +173,25 @@ ruleloop(opt::NoOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighborho
     end
 end
 
-ruleloop(opt::SparseOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:NeighborhoodRule,Vararg}}},
-         simdata::SimData, rkeys, rgrids, wkeys, wgrids) where {R,W} = begin
-
+#= Run the rule for all cells, writing the result to the dest array
+The neighborhood is copied to the rules neighborhood buffer array for performance.
+Empty blocks are skipped for NeighborhoodRules. =#
+ruleloop(opt::SparseOpt, rule, simdata::SimData, rkeys, rgrids, wkeys, wgrids,
+         griddata, src, dst, buffers, bufrules, r, blocksize, hoodsize, nrows, ncols, mask
+         ) where {R,W} = begin
     # rgrids isa Tuple && length(rgrids) > 1 && error("`SparseOpt` can't handle rules with multiple read grids yet. Use `opt=NoOpt()`")
-    r = radius(rule)
-    griddata = simdata[neighborhoodkey(rule)]
-    #= Blocks are cell smaller than the hood, because this works very nicely for
-    #looking at only 4 blocks at a time. Larger blocks mean each neighborhood is more
-    #likely to be active, smaller means handling more than 2 neighborhoods per block.
-    It would be good to test if this is the sweet spot for performance,
-    it probably isn't for game of life size grids. =#
-    blocksize = 2r
-    hoodsize = 2r + 1
-    nrows, ncols = gridsize(griddata)
-    # We unwrap offset arrays and work with the underlying array
-    src, dst = parent(source(griddata)), parent(dest(griddata))
-    srcstatus, dststatus = sourcestatus(griddata), deststatus(griddata)
-    # curstatus and newstatus track active status for 4 local blocks
-    newstatus = localstatus(griddata)
-    # Initialise status for the dest. Is this needed?
-    # deststatus(data) .= false
-    # Get the preallocated neighborhood buffers
-    # Center of the buffer for both axes
-    bufcenter = r + 1
-    bufrules = spreadbuffers(rule, init(griddata))
-    buffers = map(r -> buffer(neighborhood(r)), bufrules)
 
     #= Run the rule row by row. When we move along a row by one cell, we access only
     a single new column of data the same hight of the nighborhood, and move the existing
     data in the neighborhood buffer array accross by one column. This saves on reads
     from the main array, and focusses reads and writes in the small buffer array that
     should be in fast local memory. =#
+
+    # Initialise status for the dest. Is this needed?
+    # deststatus(data) .= false
+    srcstatus, dststatus = sourcestatus(griddata), deststatus(griddata)
+    # curstatus and newstatus track active status for 4 local blocks
+    newstatus = localstatus(griddata)
 
     # Loop down the block COLUMN
     for bi = 1:size(srcstatus, 1) - 1
@@ -206,13 +229,13 @@ ruleloop(opt::SparseOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighb
                 # Skip this block
                 skippedlastblock = true
                 # Run the rest of the chain if it exists
-                if rule isa Chain && length(rule) > 1 && length(rkeys) > 1 
+                if rule isa Chain && length(rule) > 1 && length(rkeys) > 1
                     # Loop over the grid COLUMNS inside the block
                     for j in jstart:jstop
                         # Loop over the grid ROWS inside the block
                         for b in 1:rowsinblock
                             I = i + b - 1, j
-                            ismasked(simdata, I...) && continue
+                            ismasked(mask, I...) && continue
                             read = readgrids(rkeys, rgrids, I...)
                             write = applyrule(tail(rule), simdata, read, I)
                             if wgrids isa Tuple
@@ -230,13 +253,9 @@ ruleloop(opt::SparseOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighb
 
             # Reinitialise neighborhood buffers if we have skipped a section of the array
             if skippedlastblock
-                for y = 1:hoodsize
-                    for b in 1:rowsinblock
-                        for x = 1:hoodsize
-                            val = src[i + b + x - 2, jstart + y - 1]
-                            @inbounds buffers[b][x, y] = val
-                        end
-                    end
+                for y = 1:hoodsize, b in 1:rowsinblock, x = 1:hoodsize
+                    val = src[i + b + x - 2, jstart + y - 1]
+                    @inbounds buffers[b][x, y] = val
                 end
                 skippedlastblock = false
                 freshbuffer = true
@@ -267,12 +286,11 @@ ruleloop(opt::SparseOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighb
                 # Loop over the grid ROWS inside the block
                 for b in 1:rowsinblock
                     I = i + b - 1, j
-                    ismasked(simdata, I...) && continue
+                    ismasked(mask, I...) && continue
                     # Which block row are we in
                     curblocki = b <= r ? 1 : 2
                     # Run the rule using buffer b
                     readval = readgrids(keys2vals(readkeys(rule)), rgrids, I...)
-                    #read = buf[bufcenter, bufcenter]
                     writeval = applyrule(bufrules[b], simdata, readval, I)
                     writegrids!(wgrids, writeval, I...)
                     # Update the status for the block
@@ -296,6 +314,10 @@ ruleloop(opt::SparseOpt, rule::Union{NeighborhoodRule,Chain{R,W,<:Tuple{<:Neighb
     end
     srcstatus .= dststatus
 end
+
+
+# Low-level tools for fetching, manipulating and writing 
+# grids reuired in the simulation.
 
 @generated function readgrids(rkeys::Tuple, rdata::Tuple, I...)
     expr = Expr(:tuple)
@@ -329,42 +351,42 @@ end
 # getdata retreives GridDatGridData to match the requirements of a Rule.
 
 # Choose key source
-getdata(context::_Write_, rule::Rule, simdata::AbstractSimData) =
-    getdata(context, keys(simdata), writekeys(rule), simdata::AbstractSimData)
-getdata(context::_Read_, rule::Rule, simdata::AbstractSimData) =
-    getdata(context, keys(simdata), readkeys(rule), simdata)
-@inline getdata(context, gridkeys, rulekeys, simdata::AbstractSimData) =
-    getdata(context, keys2vals(rulekeys), simdata)
+getgrids(context::_Write_, rule::Rule, simdata::AbstractSimData) =
+    getgrids(context, keys(simdata), writekeys(rule), simdata::AbstractSimData)
+getgrids(context::_Read_, rule::Rule, simdata::AbstractSimData) =
+    getgrids(context, keys(simdata), readkeys(rule), simdata)
+@inline getgrids(context, gridkeys, rulekeys, simdata::AbstractSimData) =
+    getgrids(context, keys2vals(rulekeys), simdata)
 # When there is only one grid, use its key and ignore the rule key
 # This can make scripting easier as you can safely ignore the keys
 # for smaller models.
-@inline getdata(context, gridkeys::Tuple{Symbol}, rulekeys::Tuple{Symbol}, simdata::AbstractSimData) =
-    getdata(context, (Val(gridkeys[1]),), simdata)
-@inline getdata(context, gridkeys::Tuple{Symbol}, rulekey::Symbol, simdata::AbstractSimData) =
-    getdata(context, Val(gridkeys[1]), simdata)
+@inline getgrids(context, gridkeys::Tuple{Symbol}, rulekeys::Tuple{Symbol}, simdata::AbstractSimData) =
+    getgrids(context, (Val(gridkeys[1]),), simdata)
+@inline getgrids(context, gridkeys::Tuple{Symbol}, rulekey::Symbol, simdata::AbstractSimData) =
+    getgrids(context, Val(gridkeys[1]), simdata)
 
 # Iterate when keys are a tuple
-@inline getdata(context, keys::Tuple{Val,Vararg}, simdata::AbstractSimData) = begin
-    k, d = getdata(context, keys[1], simdata)
-    ks, ds = getdata(context, tail(keys), simdata)
+@inline getgrids(context, keys::Tuple{Val,Vararg}, simdata::AbstractSimData) = begin
+    k, d = getgrids(context, keys[1], simdata)
+    ks, ds = getgrids(context, tail(keys), simdata)
     (k, ks...), (d, ds...)
 end
-@inline getdata(context, keys::Tuple{}, simdata::AbstractSimData) = (), ()
+@inline getgrids(context, keys::Tuple{}, simdata::AbstractSimData) = (), ()
 
 # Choose data source
-@inline getdata(::_Write_, key::Val{K}, simdata::AbstractSimData) where K =
+@inline getgrids(::_Write_, key::Val{K}, simdata::AbstractSimData) where K =
     key, WritableGridData(simdata[K])
-@inline getdata(::_Read_, key::Val{K}, simdata::AbstractSimData) where K =
+@inline getgrids(::_Read_, key::Val{K}, simdata::AbstractSimData) where K =
     key, simdata[K]
 
 
-combinedata(rkey, rgrids, wkey, wgrids) =
-    combinedata((rkey,), (rgrids,), (wkey,), (wgrids,))
-combinedata(rkey, rgrids, wkeys::Tuple, wgrids::Tuple) =
-    combinedata((rkey,), (rgrids,), wkeys, wgrids)
-combinedata(rkeys::Tuple, rgrids::Tuple, wkey, wgrids) =
-    combinedata(rkeys, rgrids, (wkey,), (wgrids,))
-@generated combinedata(rkeys::Tuple{Vararg{<:Val}}, rgrids::Tuple,
+combinegrids(rkey, rgrids, wkey, wgrids) =
+    combinegrids((rkey,), (rgrids,), (wkey,), (wgrids,))
+combinegrids(rkey, rgrids, wkeys::Tuple, wgrids::Tuple) =
+    combinegrids((rkey,), (rgrids,), wkeys, wgrids)
+combinegrids(rkeys::Tuple, rgrids::Tuple, wkey, wgrids) =
+    combinegrids(rkeys, rgrids, (wkey,), (wgrids,))
+@generated combinegrids(rkeys::Tuple{Vararg{<:Val}}, rgrids::Tuple,
                        wkeys::Tuple{Vararg{<:Val}}, wgrids::Tuple) = begin
     rkeys = _vals2syms(rkeys)
     wkeys = _vals2syms(wkeys)
@@ -385,9 +407,9 @@ combinedata(rkeys::Tuple, rgrids::Tuple, wkey, wgrids) =
     end
 end
 
-replacedata(simdata::AbstractSimData, wkeys, wgrids) =
-    @set simdata.data = replacedata(data(simdata), wkeys, wgrids)
-@generated replacedata(allgrids::NamedTuple, wkeys::Tuple, wgrids::Tuple) = begin
+replacegrids(simdata::AbstractSimData, wkeys, wgrids) =
+    @set simdata.grids = replacegrids(grids(simdata), wkeys, wgrids)
+@generated replacegrids(allgrids::NamedTuple, wkeys::Tuple, wgrids::Tuple) = begin
     writekeys = map(unwrap, wkeys.parameters)
     allkeys = allgrids.parameters[1]
     expr = Expr(:tuple)
@@ -404,7 +426,7 @@ replacedata(simdata::AbstractSimData, wkeys, wgrids) =
         NamedTuple{$allkeys,typeof(vals)}(vals)
     end
 end
-@generated replacedata(allgrids::NamedTuple, wkey::Val, wgrids::GridData) = begin
+@generated replacegrids(allgrids::NamedTuple, wkey::Val, wgrids::GridData) = begin
     writekey = unwrap(wkey)
     allkeys = allgrids.parameters[1]
     expr = Expr(:tuple)
@@ -423,87 +445,3 @@ end
 
 _vals2syms(x::Type{<:Tuple}) = map(v -> _vals2syms(v), x.parameters)
 _vals2syms(::Type{<:Val{X}}) where X = X
-
-#= Wrap overflow where required. This optimisation allows us to ignore
-bounds checks on neighborhoods and still use a wraparound grid. =#
-handleoverflow!(griddata) = handleoverflow!(griddata, overflow(griddata))
-handleoverflow!(griddata::GridData{T,2}, ::WrapOverflow) where T = begin
-    r = radius(griddata)
-
-    # TODO optimise this. Its mostly a placeholder so wrapping still works in GOL tests.
-    src = source(griddata)
-    nrows, ncols = gridsize(griddata)
-
-    startpadrow = startpadcol = 1-r:0
-    endpadrow = nrows+1:nrows+r
-    endpadcol = ncols+1:ncols+r
-    startrow = startcol = 1:r
-    endrow = nrows+1-r:nrows
-    endcol = ncols+1-r:ncols
-    rows = 1:nrows
-    cols = 1:ncols
-
-    # Left
-    @inbounds copyto!(src, CartesianIndices((rows, startpadcol)),
-                      src, CartesianIndices((rows, endcol)))
-    # Right
-    @inbounds copyto!(src, CartesianIndices((rows, endpadcol)),
-                      src, CartesianIndices((rows, startcol)))
-    # Top
-    @inbounds copyto!(src, CartesianIndices((startpadrow, cols)),
-                      src, CartesianIndices((endrow, cols)))
-    # Bottom
-    @inbounds copyto!(src, CartesianIndices((endpadrow, cols)),
-                      src, CartesianIndices((startrow, cols)))
-
-    # Copy four corners
-    # Top Left
-    @inbounds copyto!(src, CartesianIndices((startpadrow, startpadcol)),
-                      src, CartesianIndices((endrow, endcol)))
-    # Top Right
-    @inbounds copyto!(src, CartesianIndices((startpadrow, endpadcol)),
-                      src, CartesianIndices((endrow, startcol)))
-    # Botom Left
-    @inbounds copyto!(src, CartesianIndices((endpadrow, startpadcol)),
-                      src, CartesianIndices((startrow, endcol)))
-    # Botom Right
-    @inbounds copyto!(src, CartesianIndices((endpadrow, endpadcol)),
-                      src, CartesianIndices((startrow, startcol)))
-
-    # Wrap status
-    status = sourcestatus(griddata)
-    # status[:, 1] .|= status[:, end-1] .| status[:, end-2]
-    # status[1, :] .|= status[end-1, :] .| status[end-2, :]
-    # status[end-1, :] .|= status[1, :]
-    # status[:, end-1] .|= status[:, 1]
-    # status[end-2, :] .|= status[1, :]
-    # status[:, end-2] .|= status[:, 1]
-    # FIXME: Buggy currently, just running all in Wrap mode
-    status .= true
-    griddata
-end
-handleoverflow!(griddata::WritableGridData, ::RemoveOverflow) = begin
-    r = radius(griddata)
-    # Zero edge padding, as it can be written to in writable rules.
-    src = parent(source(griddata))
-    npadrows, npadcols = size(source(griddata))
-
-    startpadrow = startpadcol = 1:r
-    endpadrow = npadrows-r+1:npadrows
-    endpadcol = npadcols-r+1:npadcols
-    padrows, padcols = axes(src)
-
-    for j = startpadcol, i = padrows
-        src[i, j] = zero(eltype(src))
-    end
-    for j = endpadcol, i = padrows
-        src[i, j] = zero(eltype(src))
-    end
-    for j = padcols, i = startpadrow
-        src[i, j] = zero(eltype(src))
-    end
-    for j = padcols, i = endpadrow
-        src[i, j] = zero(eltype(src))
-    end
-    griddata
-end

--- a/src/outputs/array.jl
+++ b/src/outputs/array.jl
@@ -1,21 +1,27 @@
 """
-    ArrayOutput(init; tspan::Range) 
-    ArrayOutput(init, length::Integer)
+    ArrayOutput(init; tspan::AbstractRange) 
 
 A simple output that stores each step of the simulation in a vector of arrays.
 
-### Arguments:
-- `frames`: Single init array or vector of arrays
-- `length`: The length of the output.
+## Arguments:
+- `init`: initialisation `Array` or `NamedTuple` of `Array`
+
+## Keyword Argument:
+- `tspan`: `AbstractRange` timespan for the simulation
 """
 @Output mutable struct ArrayOutput{T} <: Output{T} end
 
-ArrayOutput(init, length::Integer; kwargs...) = begin
-    frames = [deepcopy(init)]
-    append!(frames, zerogrids(init, length-1))
-    ArrayOutput(; frames=frames, kwargs...)
+ArrayOutput(init; mask=nothing, tspan, kwargs...) = begin
+    frames = zerogrids(init, length(tspan))
+    frames[1] = deepcopy(init)
+    running = false
+    if length(kwargs) > 1
+        @warn "additional keyword arguments not use: $kwargs"
+    end
+    ArrayOutput(frames, init, mask, running, tspan)
 end
 
-zerogrids(initgrid::AbstractArray, nframes) = [zero(initgrid) for f in 1:nframes]
+zerogrids(initgrid::AbstractArray, nframes) = 
+    [zero(initgrid) for f in 1:nframes]
 zerogrids(initgrids::NamedTuple, nframes) =
     [map(grid -> zero(grid), initgrids) for f in 1:nframes]

--- a/src/outputs/array.jl
+++ b/src/outputs/array.jl
@@ -9,19 +9,17 @@ A simple output that stores each step of the simulation in a vector of arrays.
 ## Keyword Argument:
 - `tspan`: `AbstractRange` timespan for the simulation
 """
-@Output mutable struct ArrayOutput{T} <: Output{T} end
-
-ArrayOutput(init; mask=nothing, tspan, kwargs...) = begin
-    frames = zerogrids(init, length(tspan))
-    frames[1] = deepcopy(init)
-    running = false
-    if length(kwargs) > 1
-        @warn "additional keyword arguments not use: $kwargs"
-    end
-    ArrayOutput(frames, init, mask, running, tspan)
+mutable struct ArrayOutput{T,F<:AbstractVector{T},E} <: Output{T} 
+    frames::F
+    running::Bool
+    extent::E
 end
 
-zerogrids(initgrid::AbstractArray, nframes) = 
-    [zero(initgrid) for f in 1:nframes]
+ArrayOutput(; frames, running, extent, kwargs...) = begin
+    append!(frames, zerogrids(init(extent), length(tspan(extent))-1))
+    ArrayOutput(frames, running, extent)
+end
+
+zerogrids(initgrid::AbstractArray, nframes) = [zero(initgrid) for f in 1:nframes]
 zerogrids(initgrids::NamedTuple, nframes) =
     [map(grid -> zero(grid), initgrids) for f in 1:nframes]

--- a/src/outputs/graphic.jl
+++ b/src/outputs/graphic.jl
@@ -3,36 +3,27 @@ Outputs that display the simulation frames live.
 """
 abstract type GraphicOutput{T} <: Output{T} end
 
-(::Type{F})(o::T; kwargs...) where F <: GraphicOutput where T <: GraphicOutput = F(; 
-    frames=frames(o), 
-    starttime=starttime(o), 
-    stoptime=stoptime(o),
-    fps=fps(o), 
-    showfps=showfps(o), 
-    timestamp=timestamp(o), 
-    stampframe=stampframe(o), 
-    store=store(o),
-    kwargs...
-)
-
 """
 Mixin for graphic output fields
 """
-@premix @default_kw struct Graphic{FPS,SFPS,TS,SF}
-    fps::FPS       | 25.0
-    showfps::SFPS  | 25.0
-    timestamp::TS  | 0.0
-    stampframe::SF | 1
-    store::Bool    | false
+@premix struct Graphic{FPS,TS,SF,S}
+    fps::FPS
+    timestamp::TS
+    stampframe::SF
+    store::S
 end
+
+# Generic GraphicOutput constructor. Converts an init array to vector of arrays.
+(::Type{T})(init::Union{NamedTuple,AbstractMatrix}; mask=nothing, fps=25.0, store=false, kwargs...
+           ) where T <: GraphicOutput =
+    T(; frames=[deepcopy(init)], init=init, mask=mask, running=false, fps=fps, timestamp=0.0, 
+      stampframe=1, store=store, kwargs...)
 
 # Field getters and setters
 fps(o::Output) = nothing
 fps(o::GraphicOutput) = o.fps
 setfps!(o::Output, x) = nothing
 setfps!(o::GraphicOutput, x) = o.fps = x
-showfps(o::Output) = nothing
-showfps(o::GraphicOutput) = o.showfps
 timestamp(o::GraphicOutput) = o.timestamp
 stampframe(o::GraphicOutput) = o.stampframe
 store(o::GraphicOutput) = o.store

--- a/src/outputs/repl.jl
+++ b/src/outputs/repl.jl
@@ -31,15 +31,18 @@ REPLOutput(init)
 ```
 The default option is `:block`.
 """
-@Graphic @Output mutable struct REPLOutput{Co,St,Cu} <: GraphicOutput{T}
+mutable struct REPLOutput{T,F<:AbstractVector{T},E,GC,Co,St,Cu} <: GraphicOutput{T}
+    frames::F
+    running::Bool
+    extent::E
+    graphicconfig::GC
     color::Co  
     style::St 
     cutoff::Cu
 end
-REPLOutput(; frames, init, mask, running, tspan, fps, timestamp, stampframe, store,
-           color=:white, cutoff=0.5, style=Block()) =
-    REPLOutput(frames, init, mask, running, tspan, fps, timestamp, stampframe, 
-               store, color, style, cutoff) 
+REPLOutput(; frames, running, extent, graphicconfig,
+           color=:white, cutoff=0.5, style=Block(), kwargs...) =
+    REPLOutput(frames, running, extent, graphicconfig, color, style, cutoff) 
 
 # initialise(o::REPLOutput, args...) = begin
     # o.displayoffset .= 1

--- a/src/overflow.jl
+++ b/src/overflow.jl
@@ -1,0 +1,85 @@
+
+#= Wrap overflow where required. This optimisation allows us to ignore
+bounds checks on neighborhoods and still use a wraparound grid. =#
+handleoverflow!(griddata) = handleoverflow!(griddata, overflow(griddata))
+handleoverflow!(griddata::GridData{T,2}, ::WrapOverflow) where T = begin
+    r = radius(griddata)
+
+    # TODO optimise this. Its mostly a placeholder so wrapping still works in GOL tests.
+    src = source(griddata)
+    nrows, ncols = gridsize(griddata)
+
+    startpadrow = startpadcol = 1-r:0
+    endpadrow = nrows+1:nrows+r
+    endpadcol = ncols+1:ncols+r
+    startrow = startcol = 1:r
+    endrow = nrows+1-r:nrows
+    endcol = ncols+1-r:ncols
+    rows = 1:nrows
+    cols = 1:ncols
+
+    # Left
+    @inbounds copyto!(src, CartesianIndices((rows, startpadcol)),
+                      src, CartesianIndices((rows, endcol)))
+    # Right
+    @inbounds copyto!(src, CartesianIndices((rows, endpadcol)),
+                      src, CartesianIndices((rows, startcol)))
+    # Top
+    @inbounds copyto!(src, CartesianIndices((startpadrow, cols)),
+                      src, CartesianIndices((endrow, cols)))
+    # Bottom
+    @inbounds copyto!(src, CartesianIndices((endpadrow, cols)),
+                      src, CartesianIndices((startrow, cols)))
+
+    # Copy four corners
+    # Top Left
+    @inbounds copyto!(src, CartesianIndices((startpadrow, startpadcol)),
+                      src, CartesianIndices((endrow, endcol)))
+    # Top Right
+    @inbounds copyto!(src, CartesianIndices((startpadrow, endpadcol)),
+                      src, CartesianIndices((endrow, startcol)))
+    # Botom Left
+    @inbounds copyto!(src, CartesianIndices((endpadrow, startpadcol)),
+                      src, CartesianIndices((startrow, endcol)))
+    # Botom Right
+    @inbounds copyto!(src, CartesianIndices((endpadrow, endpadcol)),
+                      src, CartesianIndices((startrow, startcol)))
+
+    # Wrap status
+    status = sourcestatus(griddata)
+    # status[:, 1] .|= status[:, end-1] .| status[:, end-2]
+    # status[1, :] .|= status[end-1, :] .| status[end-2, :]
+    # status[end-1, :] .|= status[1, :]
+    # status[:, end-1] .|= status[:, 1]
+    # status[end-2, :] .|= status[1, :]
+    # status[:, end-2] .|= status[:, 1]
+    # FIXME: Buggy currently, just running all in Wrap mode
+    status .= true
+    griddata
+end
+
+handleoverflow!(griddata::WritableGridData, ::RemoveOverflow) = begin
+    r = radius(griddata)
+    # Zero edge padding, as it can be written to in writable rules.
+    src = parent(source(griddata))
+    npadrows, npadcols = size(source(griddata))
+
+    startpadrow = startpadcol = 1:r
+    endpadrow = npadrows-r+1:npadrows
+    endpadcol = npadcols-r+1:npadcols
+    padrows, padcols = axes(src)
+
+    for j = startpadcol, i = padrows
+        src[i, j] = zero(eltype(src))
+    end
+    for j = endpadcol, i = padrows
+        src[i, j] = zero(eltype(src))
+    end
+    for j = padcols, i = startpadrow
+        src[i, j] = zero(eltype(src))
+    end
+    for j = padcols, i = endpadrow
+        src[i, j] = zero(eltype(src))
+    end
+    griddata
+end

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -40,8 +40,6 @@ struct NoOpt <: PerformanceOpt end
 abstract type AbstractRuleset end
 
 # Getters
-init(rs::AbstractRuleset) = rs.init
-mask(rs::AbstractRuleset) = rs.mask
 overflow(rs::AbstractRuleset) = rs.overflow
 opt(rs::AbstractRuleset) = rs.opt
 cellsize(rs::AbstractRuleset) = rs.cellsize
@@ -51,16 +49,12 @@ ruleset(rs::AbstractRuleset) = rs
 Base.step(rs::AbstractRuleset) = timestep(rs)
 
 """
-    Ruleset(rules...; init=nothing, mask=nothing, overflow=RemoveOverflow(), opt=SparseeOpt(), cellsize=1, timestep=1)
+    Ruleset(rules...; overflow=RemoveOverflow(), opt=SparseOpt(), cellsize=1, timestep=1)
 
-A container for holding a sequence of `Rule`, an `init`
-array and other simulaiton details. Rules will be run in the
-order they are passed, ie. `Ruleset(rule1, rule2, rule3)`.
+A container for holding a sequence of `Rule`and simulaiton details like overflow handing 
+and optimisation.  Rules will be run in the order they are passed, ie. `Ruleset(rule1, rule2, rule3)`.
 
 ## Keyword Arguments
-- `init`: init grid(s) to use if none are supplied to `sim!`.
-  An `AbstractArray`, a `NamedTuple` of `AbsractactArray`, or `nothing`.
-- `mask`: An array of Bool matching the size of `init`. Cells that are `false` will not run.
 - `overflow`: determine what to do with overflow of grid edges.
   Options are `RemoveOverflow()` or `WrapOverflow()`.
   Available from `applyrule` with `overflow(data)`
@@ -69,17 +63,14 @@ order they are passed, ie. `Ruleset(rule1, rule2, rule3)`.
 - `timestep`: timestep size for all rules. eg. `Month(1)` or `1u"s"`.
   Available from `applyrule` with `timestep(data)`
 """
-@default_kw @flattenable mutable struct Ruleset{I,M,O<:Overflow,Op<:PerformanceOpt,C,T
-    } <: AbstractRuleset
+@default_kw @flattenable mutable struct Ruleset{O<:Overflow,Op<:PerformanceOpt,C,T} <: AbstractRuleset
     # Rules are intentionally not type stable. This allows `precalc` and Interact.jl 
     # updates to change the rule type. Function barriers remove any performance overheads.
     rules::Tuple{Vararg{<:Rule}} | ()               | true
-    init::I                      | nothing          | false
-    mask::M                      | nothing          | false
     overflow::O                  | RemoveOverflow() | false
     opt::Op                      | SparseOpt()      | false
     cellsize::C                  | 1                | false
-    timestep::T                  | 1                | false
+    timestep::T                  | nothing          | false
 end
 Ruleset(rules::Vararg{<:Rule}; kwargs...) = Ruleset(; rules=rules, kwargs...)
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -49,19 +49,16 @@ ruleset(rs::AbstractRuleset) = rs
 Base.step(rs::AbstractRuleset) = timestep(rs)
 
 """
-    Ruleset(rules...; overflow=RemoveOverflow(), opt=SparseOpt(), cellsize=1, timestep=1)
+    Ruleset(rules...; overflow=RemoveOverflow(), opt=SparseOpt(), cellsize=1, timestep=nothing)
 
 A container for holding a sequence of `Rule`and simulaiton details like overflow handing 
 and optimisation.  Rules will be run in the order they are passed, ie. `Ruleset(rule1, rule2, rule3)`.
 
 ## Keyword Arguments
-- `overflow`: determine what to do with overflow of grid edges.
-  Options are `RemoveOverflow()` or `WrapOverflow()`.
-  Available from `applyrule` with `overflow(data)`
+- `opt`: a [`PerformanceOpt`](@ref) to specificy optimisations like [`SparseOpt`](@ref).
+- `overflow`: what to do with overflow of grid edges. Options are `RemoveOverflow()` or `WrapOverflow()`.
 - `cellsize`: Size of cells.
-  Available from `applyrule` with `timestep(data)`
-- `timestep`: timestep size for all rules. eg. `Month(1)` or `1u"s"`.
-  Available from `applyrule` with `timestep(data)`
+- `timestep`: fixed timestep where this is reuired for some rules. eg. `Month(1)` or `1u"s"`.
 """
 @default_kw @flattenable mutable struct Ruleset{O<:Overflow,Op<:PerformanceOpt,C,T} <: AbstractRuleset
     # Rules are intentionally not type stable. This allows `precalc` and Interact.jl 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,7 +48,7 @@ unwrap(::Val{X}) where X = X
 unwrap(::Type{Val{X}}) where X = X
 
 """
-    isinferred(ruleset::Ruleset, starttime=1; init=nothing)
+    isinferred(output::Output, ruleset::Ruleset)
 
 Test if a custom rule return type is inferred and correct.
 Type-stability can give orders of magnitude improvements in performance.
@@ -58,11 +58,12 @@ it must be passed in as a keyword argument.
 
 Passing `starttime` is optional, in case the time type has some effect on the rule.
 """
-isinferred(ruleset::Ruleset, starttime=1; init=nothing) = begin
-    init_ = chooseinit(DynamicGrids.init(ruleset), init)
-    simdata = SimData(init_, ruleset, starttime)
+isinferred(output::Output, rules::Rule...) = 
+    isinferred(output, Ruleset(rules...))
+isinferred(output::Output, ruleset::Ruleset) = begin
+    simdata = SimData(init(output), mask(output), ruleset, tspan(output))
     map(rules(ruleset)) do rule
-        isinferred(simdata, rule, init_)
+        isinferred(simdata, rule, init(output))
     end
     true
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,13 +37,14 @@ end
 """
 Check if a cell is masked, using the passed-in mask grid.
 """
-@inline ismasked(data::AbstractSimData, I...) = ismasked(mask(data), I...)
-@inline ismasked(data::GridData, I...) = ismasked(mask(data), I...)
-@inline ismasked(mask::Nothing, I...) = false
-@inline ismasked(mask::AbstractArray, I...) = begin
+ismasked(data::AbstractSimData, I...) = ismasked(mask(data), I...)
+ismasked(data::GridData, I...) = ismasked(mask(data), I...)
+ismasked(mask::Nothing, I...) = false
+ismasked(mask::AbstractArray, I...) = begin
     @inbounds return !(mask[I...])
 end
 
+unwrap(x) = x
 unwrap(::Val{X}) where X = X
 unwrap(::Type{Val{X}}) where X = X
 
@@ -61,7 +62,9 @@ Passing `starttime` is optional, in case the time type has some effect on the ru
 isinferred(output::Output, rules::Rule...) = 
     isinferred(output, Ruleset(rules...))
 isinferred(output::Output, ruleset::Ruleset) = begin
-    simdata = SimData(init(output), mask(output), ruleset, tspan(output))
+    ext = extent(output)
+    ext = @set ext.init = asnamedtuple(init(output))
+    simdata = SimData(ext, ruleset)
     map(rules(ruleset)) do rule
         isinferred(simdata, rule, init(output))
     end
@@ -74,7 +77,7 @@ isinferred(simdata::SimData, rule::Rule, init::AbstractArray) = begin
     true
 end
 isinferred(simdata::SimData, rule::ManualRule, init::AbstractArray) = begin
-    simdata = @set simdata.data = map(WritableGridData, simdata.data)
+    simdata = @set simdata.grids = map(WritableGridData, simdata.grids)
     @inferred applyrule!(rule, simdata, init[1, 1], (1, 1))
     true
 end
@@ -92,3 +95,6 @@ allocbuffers(init::AbstractArray, r::Int) = Tuple(allocbuffer(init, r) for i in 
 allocbuffer(init::AbstractArray, hood::Neighborhood) = allocbuffer(init, radius(hood))
 allocbuffer(init::AbstractArray, r::Int) = zeros(eltype(init), 2r+1, 2r+1)
 
+asnamedtuple(x::NamedTuple) = x
+asnamedtuple(x::AbstractArray) = (_default_=x,)
+asnamedtuple(e::Extent) = Extent(asnamedtuple(init(e)), mask(e), tspan(e), aux(e))

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -43,7 +43,7 @@ using DynamicGrids: SimData, radius, rules, readkeys, writekeys,
 
     ruleset = Ruleset(chain)
     init = (a=agrid, b=bgrid, c=cgrid, d=dgrid, e=egrid)
-    data = SimData(init, ruleset, 1)
+    data = SimData(init, nothing, ruleset, 1)
 
     @test radius(ruleset) == (b=0, c=0, d=0, e=0, a=0)
 
@@ -59,8 +59,8 @@ using DynamicGrids: SimData, radius, rules, readkeys, writekeys,
     # b = @benchmark applyrule($chain, $data, $state, $ind)
     # @test b.allocs == 0
 
-    output = ArrayOutput(init, 3)
-    sim!(output, ruleset; init=init, tspan=(1, 3))
+    output = ArrayOutput(init; tspan=1:3)
+    sim!(output, ruleset)
 
     @test output[2][:a] == [2 0 0  
                             0 0 4]
@@ -131,11 +131,11 @@ end
     @test lastindex(chain) === 2
 
     ruleset = Ruleset(chain; opt=NoOpt())
-    noopt_output = ArrayOutput(init, 3)
+    noopt_output = ArrayOutput(init; tspan=1:3)
     @btime sim!($noopt_output, $ruleset; init=$init)
     
     ruleset = Ruleset(Chain(hoodrule, rule); opt=SparseOpt())
-    sparseopt_output = ArrayOutput(init, 3)
+    sparseopt_output = ArrayOutput(init; tspan=1:3)
     @btime sim!($sparseopt_output, $ruleset; init=$init)
 
     noopt_output[2][:a] == sparseopt_output[2][:a] ==

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -1,7 +1,7 @@
 using DynamicGrids, Test, BenchmarkTools
 
 using DynamicGrids: SimData, radius, rules, readkeys, writekeys, 
-    applyrule, sumneighbors, neighborhood, update_chainstate, neighborhoodkey
+    applyrule, sumneighbors, neighborhood, update_chainstate, neighborhoodkey, Extent
 
 @testset "CellRule chain" begin
 
@@ -43,7 +43,7 @@ using DynamicGrids: SimData, radius, rules, readkeys, writekeys,
 
     ruleset = Ruleset(chain)
     init = (a=agrid, b=bgrid, c=cgrid, d=dgrid, e=egrid)
-    data = SimData(init, nothing, ruleset, 1)
+    data = SimData(Extent(init=init, tspan=1:1), ruleset)
 
     @test radius(ruleset) == (b=0, c=0, d=0, e=0, a=0)
 
@@ -92,8 +92,8 @@ end
 
 @testset "NeighbourhoodRule, CellRule chain" begin
 
-    hoodrule = Neighbors(read=:a) do hood, a
-        sum(hood)
+    hoodrule = Neighbors(read=:a) do neighborhodhood, cell
+        sum(neighborhodhood)
     end
 
     rule = Cell{Tuple{:a,:c},:b}() do b, c
@@ -132,7 +132,7 @@ end
 
     ruleset = Ruleset(chain; opt=NoOpt())
     noopt_output = ArrayOutput(init; tspan=1:3)
-    @btime sim!($noopt_output, $ruleset; init=$init)
+    @btime sim!($noopt_output, $ruleset)
     
     ruleset = Ruleset(Chain(hoodrule, rule); opt=SparseOpt())
     sparseopt_output = ArrayOutput(init; tspan=1:3)

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,8 +1,7 @@
 using DynamicGrids, Dates, Test, Colors, ColorSchemes, FieldDefaults
 using FreeTypeAbstraction
-using DynamicGrids: grid2image, @Image, @Graphic, @Output,
-    processor, minval, maxval, normalise, SimData, isstored, isasync,
-    initialise, finalise, delay, fps, settimestamp!, timestamp,
+using DynamicGrids: grid2image, processor, minval, maxval, normalise, SimData, NoDisplayImageOutput,
+    isstored, isasync, initialise, finalise, delay, fps, settimestamp!, timestamp,
     tspan, setfps!, frames, isshowable, Red, Green, Blue, showgrid, rgb, scale
 using ColorSchemes: leonardo
 
@@ -40,20 +39,15 @@ l05 = ARGB32(get(leonardo, 0.5))
 l08 = ARGB32(get(leonardo, 0.8))
 l1 = ARGB32(get(leonardo, 1))
 
-# Define a simple image output
-@Image @Graphic @Output mutable struct TestImageOutput{} <: ImageOutput{T} end
-
-TestImageOutput(; kwargs...) = TestImageOutput(values(kwargs)...)
-
 global images = []
 
-DynamicGrids.showimage(image, o::TestImageOutput, f, t) = begin
+DynamicGrids.showimage(image, o::NoDisplayImageOutput, f, t) = begin
     push!(images, image)
     image
 end
 
 @testset "basic ImageOutput" begin
-    output = TestImageOutput(init; tspan=1:1)
+    output = NoDisplayImageOutput(init; tspan=1:1)
 
     @test parent(output) == [init]
     @test minval(output) === 0
@@ -96,7 +90,8 @@ end
 
 @testset "ColorProcessor" begin
     proc = ColorProcessor(zerocolor=(1.0,0.0,0.0))
-    output = TestImageOutput((a=init,); tspan=1:1, processor=proc, minval=0.0, maxval=10.0, store=true)
+    output = NoDisplayImageOutput((a=init,); tspan=1:1, processor=proc, minval=0.0, maxval=10.0, store=true)
+    maxval(output.imageconfig)
     @test minval(output) === 0.0
     @test maxval(output) === 10.0
     @test processor(output) == ColorProcessor(zerocolor=(1.0,0.0,0.0))
@@ -136,7 +131,7 @@ end
                       fcolor=ARGB32(1.0, 1.0, 1.0, 1.0), bcolor=ARGB32(0.0, 0.0, 0.0, 1.0))
         textconfig=TextConfig(; font=font, timepixels=pixelsize, namepixels=pixelsize)
         proc = ColorProcessor(zerocolor=ARGB32(1.0, 0.0, 0.0, 1.0), textconfig=textconfig)
-        output = TestImageOutput((t=textinit,); tspan=1:1, processor=proc, store=true)
+        output = NoDisplayImageOutput((t=textinit,); tspan=1:1, processor=proc, store=true)
         img = grid2image(proc, output, simdata, textinit, DateTime(2001))
         @test img == refimg
     end
@@ -160,7 +155,7 @@ end
         opt=SparseOpt(),
     )
     proc = SparseOptInspector()
-    output = TestImageOutput(init; 
+    output = NoDisplayImageOutput(init; 
         tspan=Date(2001, 1, 1):Day(1):Date(2001, 1, 5), 
         processor=proc, minval=0.0, maxval=1.0, store=true
     )
@@ -190,7 +185,7 @@ end
     leo = ColorProcessor(scheme=leonardo, zerocolor=z0)
     multiinit = (a = init, b = 2init)
     proc = LayoutProcessor([:a, nothing, :b], (grey, leo), nothing)
-    output = TestImageOutput(init; tspan=1:1, processor=proc, minval=(0, 0), maxval=(10, 20), store=true)
+    output = NoDisplayImageOutput(init; tspan=1:1, processor=proc, minval=(0, 0), maxval=(10, 20), store=true)
     @test minval(output) === (0, 0)
     @test maxval(output) === (10, 20)
     @test processor(output) === proc
@@ -231,7 +226,7 @@ end
         textconfig = TextConfig(; font=font, timepixels=timepixels, namepixels=namepixels)
         proc = LayoutProcessor([:a, nothing, :b], (grey, leo), textconfig)
 
-        output = TestImageOutput((t=textinit,); tspan=1:10, processor=proc, store=true, 
+        output = NoDisplayImageOutput((t=textinit,); tspan=1:10, processor=proc, store=true, 
                                  minval=(0, 0), maxval=(1, 1))
 
         img = grid2image(output, simdata, textinit, DateTime(2001));
@@ -247,7 +242,7 @@ end
                  d=[9.0 0.0 15.0 50.0 -10.0])
     proc = ThreeColorProcessor(colors=(Green(), Red(), Blue(), nothing), zerocolor=0.9, maskcolor=0.8)
     @test proc.colors === (Green(), Red(), Blue(), nothing)
-    output = TestImageOutput(multiinit; 
+    output = NoDisplayImageOutput(multiinit; 
         mask=mask, tspan=1:1, processor=proc, 
         minval=(4, 0, 5, 0), maxval=(6, 1, 10, 1), store=true
     )

--- a/test/image.jl
+++ b/test/image.jl
@@ -2,7 +2,7 @@ using DynamicGrids, Dates, Test, Colors, ColorSchemes, FieldDefaults
 using FreeTypeAbstraction
 using DynamicGrids: grid2image, @Image, @Graphic, @Output,
     processor, minval, maxval, normalise, SimData, isstored, isasync,
-    initialise, finalise, delay, fps, showfps, settimestamp!, timestamp,
+    initialise, finalise, delay, fps, settimestamp!, timestamp,
     tspan, setfps!, frames, isshowable, Red, Green, Blue, showgrid, rgb, scale
 using ColorSchemes: leonardo
 
@@ -43,6 +43,8 @@ l1 = ARGB32(get(leonardo, 1))
 # Define a simple image output
 @Image @Graphic @Output mutable struct TestImageOutput{} <: ImageOutput{T} end
 
+TestImageOutput(; kwargs...) = TestImageOutput(values(kwargs)...)
+
 global images = []
 
 DynamicGrids.showimage(image, o::TestImageOutput, f, t) = begin
@@ -51,11 +53,9 @@ DynamicGrids.showimage(image, o::TestImageOutput, f, t) = begin
 end
 
 @testset "basic ImageOutput" begin
-    output = TestImageOutput(init)
-    output = TestImageOutput(output)
+    output = TestImageOutput(init; tspan=1:1)
 
     @test parent(output) == [init]
-    @test showfps(output) === 25.0
     @test minval(output) === 0
     @test maxval(output) === 1
     @test processor(output) == ColorProcessor()
@@ -72,7 +72,7 @@ end
     push!(output, 2init)
     @test length(output) == 2
     @test output[2] == 2init
-    @test tspan(output) == (1, 1)
+    @test tspan(output) == 1:1
     @test fps(output) === 25.0
     @test setfps!(output, 1000.0) === 1000.0
     @test fps(output) === 1000.0
@@ -86,25 +86,22 @@ end
     savegif("test.gif", output)
     @test isfile("test.gif")
 
-    arrayoutput = ArrayOutput([0 0], 2)
+    arrayoutput = ArrayOutput([0 0]; tspan=1:2)
     @test minval(arrayoutput) == 0
     @test maxval(arrayoutput) == 1
-    @test processor(arrayoutput) == Greyscale()
+    @test processor(arrayoutput) == ColorProcessor()
     @test fps(arrayoutput) === nothing
-    @test showfps(arrayoutput) === nothing
-
-    TestImageOutput(arrayoutput)
 end
 
 
 @testset "ColorProcessor" begin
     proc = ColorProcessor(zerocolor=(1.0,0.0,0.0))
-    output = TestImageOutput((a=init,); processor=proc, minval=0.0, maxval=10.0, store=true)
+    output = TestImageOutput((a=init,); tspan=1:1, processor=proc, minval=0.0, maxval=10.0, store=true)
     @test minval(output) === 0.0
     @test maxval(output) === 10.0
     @test processor(output) == ColorProcessor(zerocolor=(1.0,0.0,0.0))
     @test isstored(output) == true
-    simdata = SimData(init, Ruleset(Life()), 1)
+    simdata = SimData(init, nothing, Ruleset(Life()), 1)
 
     # Test level normalisation
     normed = normalise.(output[1][:a], minval(output), maxval(output))
@@ -127,7 +124,7 @@ end
     @testset "text captions" begin
         font = "arial"
         pixelsize = 20
-        timepos = pixelsize, pixelsize
+        timepos = 2pixelsize, pixelsize
         textinit = zeros(200, 200)
         face = findfont(font)
         if face === nothing
@@ -137,14 +134,13 @@ end
         refimg = ARGB32.(map(x -> ARGB32(1.0, 0.0, 0.0, 1.0), textinit))
         renderstring!(refimg, string(DateTime(2001)), face, pixelsize, timepos...;
                       fcolor=ARGB32(1.0, 1.0, 1.0, 1.0), bcolor=ARGB32(0.0, 0.0, 0.0, 1.0))
-
         textconfig=TextConfig(; font=font, timepixels=pixelsize, namepixels=pixelsize)
         proc = ColorProcessor(zerocolor=ARGB32(1.0, 0.0, 0.0, 1.0), textconfig=textconfig)
-        output = TestImageOutput((t=textinit,); processor=proc, store=true)
-
+        output = TestImageOutput((t=textinit,); tspan=1:1, processor=proc, store=true)
         img = grid2image(proc, output, simdata, textinit, DateTime(2001))
         @test img == refimg
     end
+    
 end
 
 @testset "SparseOptInspector" begin
@@ -164,7 +160,10 @@ end
         opt=SparseOpt(),
     )
     proc = SparseOptInspector()
-    output = TestImageOutput(init; processor=proc, minval=0.0, maxval=1.0, store=true)
+    output = TestImageOutput(init; 
+        tspan=Date(2001, 1, 1):Day(1):Date(2001, 1, 5), 
+        processor=proc, minval=0.0, maxval=1.0, store=true
+    )
 
     @test minval(output) === 0.0
     @test maxval(output) === 1.0
@@ -172,7 +171,7 @@ end
     @test isstored(output) == true
 
     global images = []
-    sim!(output, ruleset; tspan=(Date(2001, 1, 1), Date(2001, 1, 5)))
+    sim!(output, ruleset)
     w, y, c = ARGB32(1), ARGB32(.5, .5, 0), ARGB32(0., .5, .5)
     @test images[1] == [
              y y y y y y y
@@ -182,6 +181,7 @@ end
              y y y y y c c
              y y y y y y y
             ]
+
 end
 
 @testset "LayoutProcessor" begin
@@ -190,15 +190,15 @@ end
     leo = ColorProcessor(scheme=leonardo, zerocolor=z0)
     multiinit = (a = init, b = 2init)
     proc = LayoutProcessor([:a, nothing, :b], (grey, leo), nothing)
-    output = TestImageOutput(init; processor=proc, minval=(0, 0), maxval=(10, 20), store=true)
+    output = TestImageOutput(init; tspan=1:1, processor=proc, minval=(0, 0), maxval=(10, 20), store=true)
     @test minval(output) === (0, 0)
     @test maxval(output) === (10, 20)
     @test processor(output) === proc
     @test isstored(output) == true
-    simdata = SimData(init, Ruleset(Life()), 1)
+    simdata = SimData(init, nothing, Ruleset(Life()), 1)
 
     # Test image is joined from :a, nothing, :b
-    @test grid2image(processor(output), output, Ruleset(), multiinit, 1) ==
+    @test grid2image(output, Ruleset(), multiinit, 1) ==
         [ARGB32(0.8, 0.8, 0.8) ARGB32(1.0, 1.0, 1.0)
          ARGB32(1.0, 0.0, 0.0) ARGB32(0.5, 0.5, 0.5)
          ARGB32(0.0, 0.0, 0.0) ARGB32(0.0, 0.0, 0.0)
@@ -209,7 +209,7 @@ end
     @testset "text captions" begin
         font = "arial"
         timepixels = 20
-        timepos = timepixels, timepixels
+        timepos = 2timepixels, timepixels
         textinit = (a=zeros(200, 200), b=zeros(200, 200))
         face = findfont(font)
         if face === nothing
@@ -221,19 +221,20 @@ end
                       fcolor=ARGB32(RGB(1.0), 1.0), bcolor=ARGB32(RGB(0.0), 1.0))
 
         namepixels = 15
-        nameposa = 2timepixels + namepixels, timepixels
+        nameposa = 3timepixels + namepixels, timepixels
         renderstring!(refimg, "a", face, namepixels, nameposa...;
                       fcolor=ARGB32(RGB(1.0), 1.0), bcolor=ARGB32(RGB(0.0), 1.0))
-        nameposb = 2timepixels + namepixels + 400, timepixels
+        nameposb = 3timepixels + namepixels + 400, timepixels
         renderstring!(refimg, "b", face, namepixels, nameposb...;
                       fcolor=ARGB32(RGB(1.0), 1.0), bcolor=ARGB32(RGB(0.0), 1.0))
 
         textconfig = TextConfig(; font=font, timepixels=timepixels, namepixels=namepixels)
         proc = LayoutProcessor([:a, nothing, :b], (grey, leo), textconfig)
 
-        output = TestImageOutput((t=textinit,); processor=proc, store=true)
+        output = TestImageOutput((t=textinit,); tspan=1:10, processor=proc, store=true, 
+                                 minval=(0, 0), maxval=(1, 1))
 
-        img = grid2image(proc, (0, 0), (1, 1), simdata, textinit, DateTime(2001));
+        img = grid2image(output, simdata, textinit, DateTime(2001));
         @test img == refimg
     end
 end
@@ -246,12 +247,15 @@ end
                  d=[9.0 0.0 15.0 50.0 -10.0])
     proc = ThreeColorProcessor(colors=(Green(), Red(), Blue(), nothing), zerocolor=0.9, maskcolor=0.8)
     @test proc.colors === (Green(), Red(), Blue(), nothing)
-    output = TestImageOutput(multiinit; processor=proc, minval=(4, 0, 5, 0), maxval=(6, 1, 10, 1), store=true)
+    output = TestImageOutput(multiinit; 
+        mask=mask, tspan=1:1, processor=proc, 
+        minval=(4, 0, 5, 0), maxval=(6, 1, 10, 1), store=true
+    )
     @test minval(output) === (4, 0, 5, 0)
     @test maxval(output) === (6, 1, 10, 1)
     @test processor(output) === proc
 
     # Test image is combined from red and green overlays
-    @test grid2image(processor(output), output, Ruleset(mask=mask), multiinit, 1) ==
+    @test grid2image(processor(output), output, Ruleset(), multiinit, 1) ==
         [ARGB32(0.1, 0.5, 0.0) ARGB32(0.2, 0.5, 0.0) ARGB32(0.0, 0.0, 1.0) ARGB32(0.9, 0.9, 0.9) ARGB32(0.8, 0.8, 0.8)]
 end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -105,20 +105,21 @@ end
     end
 
     @testset "Results match glider behaviour" begin
-        output = ArrayOutput((a=init,); tspan=tspan=(Date(2001, 1, 1):Day(2):Date(2001, 1, 14)))
+        output = ArrayOutput((a=init,); tspan=(Date(2001, 1, 1):Day(2):Date(2001, 1, 14)))
         sim!(output, rule; overflow=RemoveOverflow(), nreplicates=5)
         @test output[2][:a] == test2_rem
         @test output[3][:a] == test3_rem
         @test output[5][:a] == test5_rem
         @test output[7][:a] == test7_rem
     end
+
 end
 
 
 @testset "Life simulation with WrapOverflow" begin
     # Loop over shifing init to make sure they all work
     for i = 1:7 
-        bufs = zeros(Int, 3, 3), zeros(Int, 3, 3)
+        bufs = (zeros(Int, 3, 3), zeros(Int, 3, 3))
         rule = Life(neighborhood=RadialNeighborhood{1}(bufs))
         sparse_ruleset = Ruleset(; 
             rules=(rule,), 
@@ -169,6 +170,8 @@ end
     )
     tspan=0u"s":5u"s":6u"s"
     output = REPLOutput(init; tspan=tspan, style=Block(), fps=100, store=true)
+    DynamicGrids.isstored(output)
+    DynamicGrids.store(output)
     sim!(output, ruleset)
     resume!(output, ruleset; tstop=30u"s")
     @test output[2] == test2
@@ -179,8 +182,7 @@ end
 
 @testset "REPLOutput braile works, in Months" begin
     init_a = (_default_=init,)
-    ruleset = Ruleset(; 
-        rules=(Life(),), 
+    ruleset = Ruleset(Life(); 
         overflow=WrapOverflow(),
         timestep=Month(1),
         opt=SparseOpt(),

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -94,30 +94,23 @@ end
 
     rule = Life{:a,:a}(neighborhood=RadialNeighborhood{1}())
     ruleset = Ruleset(rule; 
-        init=(a=init,), 
         timestep=Day(2), 
         overflow=RemoveOverflow(),
         opt=NoOpt(),
     )
 
     @testset "Wrong timestep throws an error" begin
-        output = ArrayOutput(init, 7)
+        output = ArrayOutput(init; tspan=1:7)
         @test_throws ArgumentError sim!(output, ruleset; tspan=Date(2001, 1, 1):Month(1):Date(2001, 3, 1))
     end
 
     @testset "Results match glider behaviour" begin
-        output = ArrayOutput(init, 7)
-        sim!(output, rule; 
-             init=(a=init,), 
-             overflow=RemoveOverflow(),
-             opt=NoOpt(),
-             tspan=(Date(2001, 1, 1):Day(2):Date(2001, 1, 14)), 
-             nreplicates=5
-        )
-        @test output[2] == test2_rem
-        @test output[3] == test3_rem
-        @test output[5] == test5_rem
-        @test output[7] == test7_rem
+        output = ArrayOutput((a=init,); tspan=tspan=(Date(2001, 1, 1):Day(2):Date(2001, 1, 14)))
+        sim!(output, rule; overflow=RemoveOverflow(), nreplicates=5)
+        @test output[2][:a] == test2_rem
+        @test output[3][:a] == test3_rem
+        @test output[5][:a] == test5_rem
+        @test output[7][:a] == test7_rem
     end
 end
 
@@ -129,13 +122,12 @@ end
         rule = Life(neighborhood=RadialNeighborhood{1}(bufs))
         sparse_ruleset = Ruleset(; 
             rules=(rule,), 
-            init=init, 
             timestep=Day(2), 
             overflow=WrapOverflow(),
             opt=SparseOpt(),
         )
-        sparse_output = ArrayOutput(init, 7)
-        sim!(sparse_output, sparse_ruleset; init=init, tspan=(Date(2001, 1, 1), Date(2001, 1, 14)))
+        sparse_output = ArrayOutput(init; tspan=Date(2001, 1, 1):Day(2):Date(2001, 1, 14))
+        sim!(sparse_output, sparse_ruleset)
 
         @testset "SparseOpt results match glider behaviour" begin
             @test sparse_output[2] == test2
@@ -146,14 +138,12 @@ end
 
         noopt_ruleset = Ruleset(; 
             rules=(Life(),), 
-            init=init, 
             timestep=Day(2), 
             overflow=WrapOverflow(),
             opt=NoOpt(),
         )
-        noopt_output = ArrayOutput(init, 7)
-        sim!(noopt_output, noopt_ruleset; 
-             tspan=(Date(2001, 1, 1), Date(2001, 1, 14)))
+        noopt_output = ArrayOutput(init, tspan=Date(2001, 1, 1):Day(2):Date(2001, 1, 14))
+        sim!(noopt_output, noopt_ruleset) 
 
         @testset "NoOpt results match glider behaviour" begin
             @test noopt_output[2] == test2
@@ -173,13 +163,13 @@ end
 @testset "REPLOutput block works, in Unitful.jl seconds" begin
     ruleset = Ruleset(; 
         rules=(Life(),), 
-        init=init, 
         overflow=WrapOverflow(),
         timestep=5u"s",
         opt=NoOpt(),
     )
-    output = REPLOutput(init; style=Block(), fps=100, store=true)
-    sim!(output, ruleset; tspan=(0u"s", 6u"s"))
+    tspan=0u"s":5u"s":6u"s"
+    output = REPLOutput(init; tspan=tspan, style=Block(), fps=100, store=true)
+    sim!(output, ruleset)
     resume!(output, ruleset; tstop=30u"s")
     @test output[2] == test2
     @test output[3] == test3
@@ -188,19 +178,21 @@ end
 end
 
 @testset "REPLOutput braile works, in Months" begin
-    inita = (_default_=init,)
+    init_a = (_default_=init,)
     ruleset = Ruleset(; 
         rules=(Life(),), 
-        init=inita, 
         overflow=WrapOverflow(),
         timestep=Month(1),
         opt=SparseOpt(),
     )
-    output = REPLOutput(inita; style=Braile(), fps=100, store=true)
-    sim!(output, ruleset; tspan=(Date(2010, 4), Date(2010, 7)))
-    resume!(output, ruleset; tstop=Date(2010, 11))
+    tspan = Date(2010, 4):Month(1):Date(2010, 7)
+    output = REPLOutput(init_a; tspan=tspan, style=Braile(), fps=100, store=true)
+    sim!(output, ruleset)
     @test output[2][:_default_] == test2
     @test output[3][:_default_] == test3
+    @test DynamicGrids.tspan(output) == Date(2010, 4):Month(1):Date(2010, 7)
+    resume!(output, ruleset; tstop=Date(2010, 11))
+    @test DynamicGrids.tspan(output) == Date(2010, 4):Month(1):Date(2010, 11)
     @test output[5][:_default_] == test5
     @test output[7][:_default_] == test7
 end

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -1,5 +1,5 @@
 using DynamicGrids, Setfield, Test
-import DynamicGrids: neighbors, sumneighbors, SimData, radius, neighbors,
+import DynamicGrids: neighbors, sumneighbors, SimData, Extent, radius, neighbors,
        mapsetneighbor!, neighborhood, WritableGridData, dest, hoodsize, neighborhoodkey,
        allocbuffer, allocbuffers, buffer
 
@@ -28,7 +28,7 @@ end
     moore = RadialNeighborhood{1}(init[1:3, 1:3])
 
     @test buffer(moore) == init[1:3, 1:3]
-    multibuffer = RadialNeighborhood{1}((zeros(Int, 3, 3), ones(Int, 3, 4)))
+    multibuffer = RadialNeighborhood{1}(zeros(Int, 3, 3))
     @test buffer(multibuffer) == zeros(Int, 3, 3)
     @test hoodsize(moore) == 3
     @test moore[2, 2] == 0
@@ -157,7 +157,8 @@ end
     hood = RadialNeighborhood{1}()
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     ruleset = Ruleset(rule)
-    simdata = SimData(init, nothing, ruleset, 1)
+    extent = Extent((_default_=init,), nothing, 1:1, nothing)
+    simdata = SimData(extent, ruleset)
     state = 5
     index = (3, 3)
     @test mapsetneighbor!(WritableGridData(first(simdata)), hood, rule, state, index) == 40
@@ -172,7 +173,8 @@ end
     hood = CustomNeighborhood(((-1, -1), (1, 1)))
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     ruleset = Ruleset(rule)
-    simdata = SimData(init, nothing, ruleset, 1)
+    extent = Extent((_default_=init,), nothing, 1:1, nothing)
+    simdata = SimData(extent, ruleset)
     state = 1
     index = (5, 5)
     @test mapsetneighbor!(WritableGridData(first(simdata)), neighborhood(rule), rule, state, index) == 2
@@ -192,7 +194,8 @@ end
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     @test radius(rule) === 2
     ruleset = Ruleset(rule)
-    simdata = SimData(init, nothing, ruleset, 1)
+    extent = Extent((_default_=init,), nothing, 1:1, nothing)
+    simdata = SimData(extent, ruleset)
     state = 1
     index = (3, 3)
     @test mapsetneighbor!(WritableGridData(first(simdata)), neighborhood(rule), rule, state, index) == (2, 2)

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -108,7 +108,6 @@ DynamicGrids.applyrule!(rule::TestManualNeighborhoodRule{R,Tuple{W1,}}, data, st
 @testset "neighborhood rules" begin
     ruleA = TestManualNeighborhoodRule{:a,:a}(RadialNeighborhood{3}())
     ruleB = TestManualNeighborhoodRule{Tuple{:b},Tuple{:b}}(RadialNeighborhood{2}())
-    ruleset = Ruleset(ruleA, ruleB)
     @test neighbors(ruleA) isa Base.Generator
     @test neighborhood(ruleA) == RadialNeighborhood{3}()
     @test neighborhood(ruleB) == RadialNeighborhood{2}()
@@ -117,7 +116,6 @@ DynamicGrids.applyrule!(rule::TestManualNeighborhoodRule{R,Tuple{W1,}}, data, st
 
     ruleA = TestNeighborhoodRule{:a,:a}(RadialNeighborhood{3}())
     ruleB = TestNeighborhoodRule{Tuple{:b},Tuple{:b}}(RadialNeighborhood{2}())
-    ruleset = Ruleset(ruleA, ruleB)
     @test neighbors(ruleA) isa Base.Generator
     @test neighborhood(ruleA) == RadialNeighborhood{3}()
     @test neighborhood(ruleB) == RadialNeighborhood{2}()
@@ -137,8 +135,8 @@ end
     end
     @test radius(Ruleset()) == NamedTuple()
 
-    output = ArrayOutput(init, 3)
-    sim!(output, ruleset; init=init)
+    output = ArrayOutput(init; tspan=1:3)
+    sim!(output, ruleset)
     # TODO make sure 2 radii can coexist
 end
 
@@ -159,7 +157,7 @@ end
     hood = RadialNeighborhood{1}()
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     ruleset = Ruleset(rule)
-    simdata = SimData(init, ruleset, 1)
+    simdata = SimData(init, nothing, ruleset, 1)
     state = 5
     index = (3, 3)
     @test mapsetneighbor!(WritableGridData(first(simdata)), hood, rule, state, index) == 40
@@ -174,7 +172,7 @@ end
     hood = CustomNeighborhood(((-1, -1), (1, 1)))
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     ruleset = Ruleset(rule)
-    simdata = SimData(init, ruleset, 1)
+    simdata = SimData(init, nothing, ruleset, 1)
     state = 1
     index = (5, 5)
     @test mapsetneighbor!(WritableGridData(first(simdata)), neighborhood(rule), rule, state, index) == 2
@@ -194,7 +192,7 @@ end
     rule = TestManualNeighborhoodRule{:a,:a}(hood)
     @test radius(rule) === 2
     ruleset = Ruleset(rule)
-    simdata = SimData(init, ruleset, 1)
+    simdata = SimData(init, nothing, ruleset, 1)
     state = 1
     index = (3, 3)
     @test mapsetneighbor!(WritableGridData(first(simdata)), neighborhood(rule), rule, state, index) == (2, 2)

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -5,10 +5,7 @@ using DynamicGrids: isshowable, gridindex, storegrid!, SimData
     init = [10.0 11.0
             0.0   5.0]
 
-    output1 = ArrayOutput(init;
-        starttime=7,
-        stoptime=99,
-    )
+    output1 = ArrayOutput(init; tspan=1:1)
     ruleset = Ruleset(Life())
 
     @test gridindex(output1, 5) == 5 
@@ -21,31 +18,4 @@ using DynamicGrids: isshowable, gridindex, storegrid!, SimData
     push!(output1, update)
     @test length(output1) == 2
     @test output1[2] == update
-
-    # Test creting a new output from an existing output
-    output2 = ArrayOutput(output1)
-    @test length(output2) == 2
-    @test output2[2] == update
-
-    output3 = REPLOutput(output2; 
-        fps=23,
-        showfps=29,
-        timestamp=12345,
-        stampframe=4,
-        store=false,
-    )
-    @test length(output3) == 2
-    @test output3[2] == update
-
-    output4 = REPLOutput(output3)
-    @test length(output4) == 2
-    @test output2[2] == update
-
-    @test DynamicGrids.starttime(output4) == 7
-    @test DynamicGrids.stoptime(output4) == 99
-    @test DynamicGrids.fps(output4) == 23
-    @test DynamicGrids.showfps(output4) == 29
-    @test DynamicGrids.store(output4) == false
-    @test DynamicGrids.timestamp(output4) == 12345
-    @test DynamicGrids.stampframe(output4) == 4
 end

--- a/test/simulationdata.jl
+++ b/test/simulationdata.jl
@@ -1,7 +1,7 @@
 using DynamicGrids, OffsetArrays, Test, Dates
 using DynamicGrids: initdata!, data, init, mask, radius, overflow, source, 
     dest, sourcestatus, deststatus, localstatus, gridsize,
-    ruleset, grids, starttime, currentframe, grids, SimData, 
+    ruleset, grids, starttime, currentframe, grids, SimData, Extent,
     updatetime, ismasked, currenttimestep, WritableGridData
 
 inita = [0 1 1
@@ -15,7 +15,9 @@ rs = Ruleset(life, timestep=Day(1))
 tspan = DateTime(2001):Day(1):DateTime(2001, 2)
 
 @testset "initdata!" begin
-    simdata = initdata!(nothing, initab, nothing, rs, tspan, nothing)
+
+    extent = Extent(initab, nothing, tspan, nothing)
+    simdata = initdata!(nothing, extent, rs, nothing)
     @test simdata isa SimData
     @test init(simdata) == initab
     @test ruleset(simdata) === rs
@@ -62,14 +64,16 @@ tspan = DateTime(2001):Day(1):DateTime(2001, 2)
     @test eltype(grida) == Int
     @test ismasked(grida, 1, 1) == false
 
-    initdata!(simdata, initab, nothing, rs, tspan, nothing)
+    extent = Extent(initab, nothing, tspan, nothing)
+    initdata!(simdata, extent, rs, nothing)
 end
 
 @testset "initdata! with :_default_" begin
     initx = [1 0]
     rs = Ruleset(Life())
-    simdata = initdata!(nothing, initx, nothing, rs, tspan, nothing)
-    simdata2 = initdata!(simdata, initx, nothing, rs, tspan, nothing)
+    extent = Extent((_default_=initx,), nothing, tspan, nothing)
+    simdata = initdata!(nothing, extent, rs, nothing)
+    simdata2 = initdata!(simdata, extent, rs, nothing)
     @test keys(simdata2) == (:_default_,)
     @test DynamicGrids.ruleset(simdata2) === rs
     @test DynamicGrids.init(simdata2[:_default_]) == [1 0]
@@ -81,12 +85,13 @@ end
 
 @testset "initdata! with replicates" begin
     nreps = 2
-    simdata = initdata!(nothing, initab, nothing, rs, tspan, nreps)
+    extent = Extent(initab, nothing, tspan, nothing)
+    simdata = initdata!(nothing, extent, rs, nreps)
     @test simdata isa Vector{<:SimData}
     @test all(DynamicGrids.ruleset.(simdata) .== Ref(rs))
     @test all(map(DynamicGrids.tspan, simdata) .== Ref(tspan))
     @test all(keys.(DynamicGrids.grids.(simdata)) .== Ref(keys(initab)))
-    simdata2 = initdata!(simdata, initab, nothing, rs, tspan, nreps)
+    simdata2 = initdata!(simdata, extent, rs, nreps)
 end
 
 # TODO more comprehensively unit test? a lot of this is

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -21,7 +21,6 @@ using DynamicGrids: inbounds, isinbounds
         @test inbounds((-22,0), (10, 10), WrapOverflow()) == ((8,10),true)
         @test isinbounds((-22,0), (10, 10), WrapOverflow()) == true
     end
-    
 end
 
 @testset "isinferred" begin
@@ -31,15 +30,18 @@ end
                 x > 1 ? 2 : 0.0
             end
         end
-        @test_throws ErrorException isinferred(Ruleset(rule; init=rand(Int, 10, 10)))
+        output = ArrayOutput(rand(Int, 10, 10); tspan=1:10)
+        @test_throws ErrorException isinferred(output, rule)
     end
 
     @testset "return type" begin
         rule = Neighbors(RadialNeighborhood{1}(zeros(Bool, 3, 3))) do hood, x
             round(Int, x + sum(hood))
         end
-        @test isinferred(Ruleset(rule; init=rand(Int, 10, 10)))
-        @test_throws ErrorException isinferred(Ruleset(rule; init=rand(Bool, 10, 10)))
+        output = ArrayOutput(rand(Int, 10, 10); tspan=1:10)
+        @test isinferred(output, rule)
+        output = ArrayOutput(rand(Bool, 10, 10); tspan=1:10)
+        @test_throws ErrorException isinferred(output, rule)
     end
 
     @testset "let blocks" begin
@@ -47,14 +49,18 @@ end
         rule = Manual() do data, index, x
             data[1][index...] = round(Int, x + a)
         end
-        @test_throws ErrorException isinferred(Ruleset(rule; init=zeros(Int, 10, 10)))
+        output = ArrayOutput(zeros(Int, 10, 10); tspan=1:10)
+        @test_throws ErrorException isinferred(output, Ruleset(rule))
         a = 0.7
         rule = let a = a
             Manual() do data, index, x
                 data[1][index...] = round(Int, x + a)
             end
         end
-        @test isinferred(Ruleset(rule; init=zeros(Int, 10, 10)))
+
+        output = ArrayOutput(zeros(Int, 10, 10); tspan=1:10)
+        @test isinferred(output, Ruleset(rule))
     end
 
+    # TODO: implement/test for NamedTuple init
 end


### PR DESCRIPTION
Simplifies and standardizes syntax around `init` and `tspan`. Also introduces `aux` argument to hold additional datasets that should be decoupled from Rules, and moves all of these things to an Extent object on Outputs, and rebuilt in `sim!`.

Rules can now be context-independent.



