### PR TITLE
test non-number grids for StaticArrays and struct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,8 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "ColorSchemes", "ImageMagick", "SafeTestsets", "Unitful"]
+test = ["Aqua", "BenchmarkTools", "ColorSchemes", "ImageMagick", "SafeTestsets", "StaticArrays", "Unitful"]

--- a/src/neighborhoods.jl
+++ b/src/neighborhoods.jl
@@ -73,10 +73,11 @@ Moore{R}(buffer=nothing) where R =
     Moore{R,typeof(buffer)}(buffer)
 
 # Neighborhood specific `sum` for performance:w
-Base.sum(hood::Moore, cell=_centerval(hood)) =
-    sum(buffer(hood)) - cell
+Base.sum(hood::Moore) = _sum(hood, _centerval(hood))
 
 _centerval(hood) = buffer(hood)[radius(hood) + 1, radius(hood) + 1]
+
+_sum(hood::Neighborhood, cell) = sum(buffer(hood)) - cell
 
 Base.length(hood::Moore{R}) where R = (2R + 1)^2 - 1
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -25,7 +25,7 @@ the initial `R`, `W` etc fields.
     T{:_default_,:_default_,map(typeof, args)...}(args...)
 # R,W but no kwargs
 (::Type{T})(args...) where T<:Rule{R,W} where {R,W} =
-    T{typeof.(args)...}(args...)
+    T{map(typeof, args)...}(args...)
 # No R,W but kwargs
 (::Type{T})(; read=:_default_, write=:_default_, kwargs...) where T<:Rule =
     T{read,write}(; kwargs...)

--- a/src/simulationdata.jl
+++ b/src/simulationdata.jl
@@ -213,10 +213,9 @@ addpadding(init::AbstractArray{T,N}, r) where {T,N} = begin
     sze = size(init)
     paddedsize = sze .+ 2r
     paddedindices = -r + 1:sze[1] + r, -r + 1:sze[2] + r
-    sourceparent = similar(init, paddedsize...)
+    sourceparent = fill!(similar(init, paddedsize), zero(T))
     source = OffsetArray(sourceparent, paddedindices...)
-    source .= zero(eltype(source))
-    # Copy the init array to he middle section of the source array
+    # Copy the init array to the middle section of the source array
     for j in 1:size(init, 2), i in 1:size(init, 1)
         @inbounds source[i, j] = init[i, j]
     end

--- a/test/objectgrids.jl
+++ b/test/objectgrids.jl
@@ -1,0 +1,139 @@
+using DynamicGrids, StaticArrays, Test
+
+using DynamicGrids: SimData, radius, rules, readkeys, writekeys, 
+    applyrule, sumneighbors, neighborhood, neighborhoodkey, Extent
+
+@testset "CellRule that multiples a StaticArray" begin
+    rule = Cell{:grid1,:grid1}() do state
+         2state
+    end
+    init = (grid1 = fill(SA[1.0, 2.0], 5, 5),)
+    output = ArrayOutput(init; tspan=1:3)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0],
+        SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0],
+        SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], 
+        SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], 
+        SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0], SA[2.0, 4.0]
+    ], (5, 5))
+    @test output[3][:grid1] == reshape([ # Have to use reshape to construct this
+        SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0],
+        SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0],
+        SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], 
+        SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], 
+        SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0], SA[4.0, 8.0]
+    ], (5, 5))
+end
+
+@testset "Neighborhood Rule that sums a Neighborhood of StaticArrays" begin
+    rule = Neighbors{Tuple{:grid1,:grid2}, :grid1}(Moore(1)) do neighborhood, state1, state2
+        sum(neighborhood) .+ state2
+    end
+    init = (
+        grid1 = fill(SA[1.0, 2.0], 5, 5),
+        grid2 = fill(0.5, 5, 5),
+    )
+    output = ArrayOutput(init; tspan=1:2)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        SA[3.5, 6.5],  SA[5.5, 10.5], SA[5.5, 10.5], SA[5.5, 10.5], SA[3.5, 6.5],
+        SA[5.5, 10.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[5.5, 10.5],
+        SA[5.5, 10.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[5.5, 10.5], 
+        SA[5.5, 10.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[8.5, 16.5], SA[5.5, 10.5], 
+        SA[3.5, 6.5],  SA[5.5, 10.5], SA[5.5, 10.5], SA[5.5, 10.5], SA[3.5, 6.5]
+    ], (5, 5))
+end
+
+@testset "ManualRule randomly updates a StaticArray" begin
+    rule = Manual{:grid1,:grid1}() do data, I, state
+        if I == (2, 2) || I == (1, 3)
+            data[:grid1][I...] = SA[99.0, 100.0]
+        end
+    end
+    init = (grid1 = fill(SA[0.0, 0.0], 3, 3),)
+    output = ArrayOutput(init; tspan=1:2)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        SA[0.0, 0.0], SA[0.0, 0.0], SA[0.0, 0.0], 
+        SA[0.0, 0.0], SA[99.0, 100.0], SA[0.0, 0.0], 
+        SA[99.0, 100.0], SA[0.0, 0.0], SA[0.0, 0.0]
+    ], (3, 3))
+end
+
+
+struct TestStruct{A,B}
+    a::A
+    b::B
+end
+const TS = TestStruct
+
+Base.:*(ts::TestStruct, x::Number) = TestStruct(x * ts.a, x * ts.b) 
+Base.:*(x::Number, ts::TestStruct) = TestStruct(x * ts.a, x * ts.b)
+Base.:+(ts::TestStruct, x::Number) = TestStruct(x + ts.a, x + ts.b) 
+Base.:+(x::Number, ts::TestStruct) = TestStruct(x + ts.a, x + ts.b)
+Base.:+(ts1::TestStruct, ts2::TestStruct) = TestStruct(ts1.a + ts2.a, ts1.b + ts2.b)
+Base.:-(ts::TestStruct, x::Number) = TestStruct(x - ts.a, x - ts.b) 
+Base.:-(x::Number, ts::TestStruct) = TestStruct(x - ts.a, x - ts.b)
+Base.:-(ts1::TestStruct, ts2::TestStruct) = TestStruct(ts1.a - ts2.a, ts1.b - ts2.b)
+
+Base.zero(::Type{<:TestStruct{T1,T2}}) where {T1,T2} = TestStruct(zero(T1), zero(T2))
+
+
+@testset "CellRule that multiples a struct" begin
+    rule = Cell{:grid1,:grid1}() do state
+         2state
+    end
+    init = (grid1 = fill(TS(1.0, 2.0), 5, 5),)
+    output = ArrayOutput(init; tspan=1:3)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0),
+        TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0),
+        TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), 
+        TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), 
+        TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0), TS(2.0, 4.0)
+    ], (5, 5))
+    @test output[3][:grid1] == reshape([ # Have to use reshape to construct this
+        TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0),
+        TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0),
+        TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), 
+        TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), 
+        TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0), TS(4.0, 8.0)
+    ], (5, 5))
+end
+
+@testset "Neighborhood Rule that sums a Neighborhood of stucts" begin
+    rule = Neighbors{Tuple{:grid1,:grid2}, :grid1}(Moore(1)) do neighborhood, state1, state2
+        sum(neighborhood) + state2
+    end
+    init = (
+        grid1 = fill(TS(1.0, 2.0), 5, 5),
+        grid2 = fill(0.5, 5, 5),
+    )
+    output = ArrayOutput(init; tspan=1:2)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        TS(3.5, 6.5),  TS(5.5, 10.5), TS(5.5, 10.5), TS(5.5, 10.5), TS(3.5, 6.5),
+        TS(5.5, 10.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(5.5, 10.5),
+        TS(5.5, 10.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(5.5, 10.5), 
+        TS(5.5, 10.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(8.5, 16.5), TS(5.5, 10.5), 
+        TS(3.5, 6.5),  TS(5.5, 10.5), TS(5.5, 10.5), TS(5.5, 10.5), TS(3.5, 6.5)
+    ], (5, 5))
+end
+
+@testset "ManualRule randomly updates a struct" begin
+    rule = Manual{:grid1,:grid1}() do data, I, state
+        if I == (2, 2) || I == (1, 3)
+            data[:grid1][I...] = TS(99.0, 100.0)
+        end
+    end
+    init = (grid1 = fill(TS(0.0, 0.0), 3, 3),)
+    output = ArrayOutput(init; tspan=1:2)
+    sim!(output, rule)
+    @test output[2][:grid1] == reshape([ # Have to use reshape to construct this
+        TS(0.0, 0.0), TS(0.0, 0.0), TS(0.0, 0.0), 
+        TS(0.0, 0.0), TS(99.0, 100.0), TS(0.0, 0.0), 
+        TS(99.0, 100.0), TS(0.0, 0.0), TS(0.0, 0.0)
+    ], (3, 3))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ end
 @time @safetestset "utils" begin include("utils.jl") end
 @time @safetestset "outputs" begin include("outputs.jl") end
 @time @safetestset "integration" begin include("integration.jl") end
+@time @safetestset "object grids" begin include("objectgrids.jl") end
 @time @safetestset "show" begin include("show.jl") end
 # ImageMagick breaks in windows travis for some reason
 if !Sys.iswindows() 


### PR DESCRIPTION
This PR fixes and tests using non-number objects in grids, such as structs and StaticArrays, as discussed in #62

@virgile-baudrot you can probabily use some of the code in these new tests as a template for any kind of StaticArray
or struct based models. Let me know if you have any issues with it, its great to get this all smoothed out.