### PR TITLE
generalise kernel to accept any neighborhood

### DIFF
--- a/src/auxilary.jl
+++ b/src/auxilary.jl
@@ -2,31 +2,31 @@
 _auxval(data::AbstractSimData, key::Union{Aux,Symbol}, I...) = 
     _auxval(aux(data, key), data, key, I...)
 _auxval(A::AbstractMatrix, data::SimData, key::Union{Aux,Symbol}, y, x) = A[y, x]
-function _auxval(A::AbstractDimArray{<:Any,2}, data::SimData, key::Union{Aux,Symbol}, y, x)
+# function _auxval(A::AbstractDimArray{<:Any,2}, data::SimData, key::Union{Aux,Symbol}, y, x)
     # X = DD.basetypeof(dims(A, XDim))
     # Y = DD.basetypeof(dims(A, YDim))
-    A[y, x]
-end
+    # A[y, x]
+# end
 function _auxval(A::AbstractDimArray{<:Any,3}, data::SimData, key::Union{Aux,Symbol}, y, x)
     # X = DD.basetypeof(dims(A, XDim))
     # Y = DD.basetypeof(dims(A, YDim))
     A[y, x, auxframe(data, key)]
 end
 
-function _boundscheck_aux(data::SimData, auxkey::Aux{Key}) where Key
+function boundscheck_aux(data::SimData, auxkey::Aux{Key}) where Key
     a = aux(data)
-    (a isa NamedTuple && haskey(a, Key)) || _auxmissingerror(Key)
+    (a isa NamedTuple && haskey(a, Key)) || _auxmissingerror(Key, a)
     gsize = gridsize(data)
     asize = size(a[Key], 1), size(a[Key], 2)
     if asize != gsize
         _auxsizeerror(Key, asize, gsize)
     end
+    return true
 end
 
-@noinline _auxmissingerror(key, asize, gsize) =
-    error("Aux grid $key is not present in aux")
+@noinline _auxmissingerror(key, aux) = error("Aux data $key is not present in aux")
 @noinline _auxsizeerror(key, asize, gsize) =
-    error("Aux grid $key is size $asize does not match grid size $gsize")
+    error("Aux data $key is size $asize does not match grid size $gsize")
 
 _calc_auxframe(data) = _calc_auxframe(aux(data), data)
 _calc_auxframe(aux::NamedTuple, data) = map(A -> _calc_auxframe(A, data), aux)

--- a/src/boundaries.jl
+++ b/src/boundaries.jl
@@ -1,6 +1,6 @@
 # See interface docs
-@inline inbounds(xs::Tuple, data::SimData) = inbounds(xs, first(data))
-@inline inbounds(xs::Tuple, data::GridData) = inbounds(xs, gridsize(data), boundary(data))
+@inline inbounds(xs::Tuple, data::Union{GridData,SimData}) = 
+    inbounds(xs, gridsize(data), boundary(data))
 @inline function inbounds(xs::Tuple, maxs::Tuple, boundary)
     a, inbounds_a = inbounds(xs[1], maxs[1], boundary)
     b, inbounds_b = inbounds(xs[2], maxs[2], boundary)
@@ -19,10 +19,10 @@ end
     end
 end
 
-# See interface docs
 @inline isinbounds(x::Tuple, data::Union{SimData,GridData}) =
     isinbounds(x::Tuple, gridsize(data))
 @inline isinbounds(xs::Tuple, maxs::Tuple) = all(isinbounds.(xs, maxs))
+
 @inline isinbounds(x::Number, max::Number) = x >= one(x) && x <= max
 
 

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -26,7 +26,6 @@ Base.lastindex(d::GridData) = lastindex(source(d))
 init(d::GridData) = d.init
 mask(d::GridData) = d.mask
 radius(d::GridData{<:Any,<:Any,R}) where R = R
-radius(d::Tuple{<:GridData,Vararg}) = map(radius, d)
 proc(d::GridData) = d.proc
 opt(d::GridData) = d.opt
 boundary(d::GridData) = d.boundary
@@ -39,8 +38,6 @@ gridsize(d::GridData) = size(init(d))
 gridsize(A::AbstractArray) = size(A)
 gridsize(nt::NamedTuple) = gridsize(first(nt))
 gridsize(nt::NamedTuple{(),Tuple{}}) = 0, 0
-gridsize(t::Tuple) = gridsize(first(t))
-gridsize(t::Tuple{}) = 0, 0
 
 
 """

--- a/src/life.jl
+++ b/src/life.jl
@@ -47,7 +47,7 @@ nothing
 ```
 
 ![REPL Life](https://raw.githubusercontent.com/cesaraustralia/DynamicGrids.jl/media/life.gif)
-"""
+""" 
 struct Life{R,W,N,B,S,L} <: NeighborhoodRule{R,W}
     "A Neighborhood, usually Moore(1)"
     neighborhood::N
@@ -57,28 +57,26 @@ struct Life{R,W,N,B,S,L} <: NeighborhoodRule{R,W}
     survive::S
     lookup::L
 end
-Life{R,W}(neighborhood::N, born::B, survive::S, lookup_) where {R,W,N,B,S} = begin
+function Life{R,W}(neighborhood::N, born::B, survive::S, lookup_) where {R,W,N,B,S}
     lookup = Tuple(i in born for i in 0:8), Tuple(i in survive for i in 0:8)
     Life{R,W,N,B,S,typeof(lookup)}(neighborhood, born, survive, lookup)
 end
-Life{R,W}(neighborhood, born, survive) where {R,W} =
+function Life{R,W}(neighborhood, born, survive) where {R,W}
     Life{R,W}(neighborhood, born, survive, nothing)
-Life{R,W}(; neighborhood=Moore(1),
-          born=Param(3, bounds=(0, 8)),
-          survive=(Param(2, bounds=(0, 8)), Param(3, bounds=(0, 8))),
-         ) where {R,W} =
+end
+function Life{R,W}(; 
+    neighborhood=Moore(1),
+    born=Param(3, bounds=(0, 8)),
+    survive=(Param(2, bounds=(0, 8)), Param(3, bounds=(0, 8))),
+) where {R,W}
     Life{R,W}(neighborhood, born, survive, nothing)
+end
 
-function setbuffer(r::Life{R,W,N,B,S,L}, buffer) where {R,W,N,B,S,L} 
-    hood = setbuffer(r.neighborhood, buffer)
+function _setbuffer(r::Life{R,W,N,B,S,L}, buffer) where {R,W,N,B,S,L} 
+    hood = _setbuffer(r.neighborhood, buffer)
     Life{R,W,typeof(hood),B,S,L}(hood, r.born, r.survive, r.lookup)
 end
 
-"""
-    applyrule(data::SimData, rule::Life, state, I)
-
-Applies game of life rule to current cell, returning `Bool`.
-"""
 function applyrule(data::SimData, rule::Life, state, I)
     rule.lookup[state + 1][sum(neighbors(rule)) + 1]
 end

--- a/src/maprules.jl
+++ b/src/maprules.jl
@@ -75,9 +75,6 @@ end
 _to_readonly(data::Tuple) = map(ReadableGridData, data)
 _to_readonly(data::WritableGridData) = ReadableGridData(data)
 
-_hassparseopt(wgrids::Tuple) = any(o -> o isa SparseOpt, map(opt, wgrids))
-_hassparseopt(wgrid) = opt(wgrid) isa SparseOpt
-
 const NeedsBuffer = Union{NeighborhoodRule,Chain{<:Any,<:Any,<:Tuple{<:NeighborhoodRule,Vararg}}}
 
 function maprule!(
@@ -336,6 +333,9 @@ end
 ) where R
     @inbounds buffer[R + 1, R + 1]
 end
+
+@inline _keys2vals(keys::Tuple) = map(Val, keys)
+@inline _keys2vals(key::Symbol) = Val(key)
 
 # Generate an SArray from the main array and the last SArray
 @generated function _update_buffers(

--- a/src/neighborhoods.jl
+++ b/src/neighborhoods.jl
@@ -12,26 +12,24 @@ The main kinds of neighborhood are demonstrated below:
 Moore{3}()
 ```
 """
-abstract type Neighborhood{R} end
+abstract type Neighborhood{R,L} end
 
-ConstructionBase.constructorof(::Type{<:T}) where T <: Neighborhood{R} where R =
-    T.name.wrapper{R}
+ConstructionBase.constructorof(::Type{<:T}) where T <: Neighborhood{R,L} where {R,L} =
+    T.name.wrapper{R,L}
 
 radius(hood::Neighborhood{R}) where R = R
 _buffer(hood::Neighborhood) = hood._buffer
 @inline positions(hood::Neighborhood, I) = (I .+ o for o in offsets(hood))
 
 Base.eltype(hood::Neighborhood) = eltype(_buffer(hood))
+Base.length(hood::Neighborhood{<:Any,L}) where L = L
 Base.iterate(hood::Neighborhood, args...) = iterate(neighbors(hood), args...)
 Base.getindex(hood::Neighborhood, I...) = getindex(_buffer(hood), I...)
-Base.setindex!(hood::Neighborhood, val, I...) = setindex!(_buffer(hood), val, I...)
-Base.copyto!(dest::Neighborhood, dof, source::Neighborhood, sof, N) =
-    copyto!(_buffer(dest), dof, _buffer(source), sof, N)
 
 """
 Moore-style square neighborhoods
 """
-abstract type RadialNeighborhood{R} <: Neighborhood{R} end
+abstract type RadialNeighborhood{R,L} <: Neighborhood{R,L} end
 
 """
     Moore(radius::Int=1)
@@ -39,7 +37,7 @@ abstract type RadialNeighborhood{R} <: Neighborhood{R} end
 Moore neighborhoods define the neighborhood as all cells within a horizontal or
 vertical distance of the central cell. The central cell is omitted.
 """
-struct Moore{R,B} <: RadialNeighborhood{R}
+struct Moore{R,L,B} <: RadialNeighborhood{R,L}
     _buffer::B
 end
 # Buffer is updated later during the simulation.
@@ -47,8 +45,9 @@ end
 # This might be bad design. SimData could instead hold a list of
 # ruledata for the rule that holds this buffer, with
 # the neighborhood. So you can do neighbors(data)
-Moore(radius::Int=1, _buffer=nothing) = Moore{radius}(_buffer)
-Moore{R}(_buffer=nothing) where R = Moore{R,typeof(_buffer)}(_buffer)
+Moore(radius::Int=1) = Moore{radius}()
+Moore{R}(_buffer=nothing) where R = Moore{R,(2R+1)^2-1}(_buffer)
+Moore{R,L}(_buffer::B=nothing) where {R,L,B} = Moore{R,L,B}(_buffer)
 
 @inline function neighbors(hood::Moore{R}) where R
     # Use linear indexing
@@ -59,14 +58,12 @@ end
 @inline function offsets(hood::Moore{R}) where R
     ((i, j) for j in -R:R, i in -R:R if i != (0, 0))
 end
-@inline _setbuffer(n::Moore{R}, buf::B2) where {R,B2} = Moore{R,B2}(buf)
+@inline _setbuffer(n::Moore{R,L}, buf::B2) where {R,L,B2} = Moore{R,L,B2}(buf)
 
-Base.length(hood::Moore{R}) where R = (2R + 1)^2 - 1
-# Neighborhood specific `sum` for performance:w
-Base.sum(hood::Moore) = _sum(hood, _centerval(hood))
+# Neighborhood specific `sum` for performance
+Base.sum(hood::Moore) = sum(_buffer(hood)) - _centerval(hood)
 
 _centerval(hood::Neighborhood{R}) where R = _buffer(hood)[R + 1, R + 1]
-_sum(hood::Neighborhood, cell) = sum(_buffer(hood)) - cell
 
 
 """
@@ -74,9 +71,8 @@ Abstract supertype for window neighborhoods.
 
 These are radial neighborhoods that inlude the central cell.
 """
-abstract type AbstractWindow{R} <: RadialNeighborhood{R} end
+abstract type AbstractWindow{R,L} <: RadialNeighborhood{R,L} end
 
-Base.length(hood::AbstractWindow{R}) where R = (2R + 1)^2
 neighbors(hood::AbstractWindow) = _buffer(hood)
 
 # The central cell is included
@@ -88,14 +84,15 @@ neighbors(hood::AbstractWindow) = _buffer(hood)
 A neighboorhood of radius R that includes the central cell.
 `R = 1` gives a 3x3 matrix.
 """
-struct Window{R,B} <: AbstractWindow{R}
+struct Window{R,L,B} <: AbstractWindow{R,L}
     _buffer::B
 end
-@inline Window{R}() where R = Window{R,Nothing}(nothing)
 @inline Window(R::Int) = Window{R}()
+@inline Window{R}(_buffer=nothing) where R = Window{R,(2R+1)^2}(_buffer)
+@inline Window{R,L}(_buffer::B=nothing) where {R,L,B} = Window{R,L,B}(_buffer)
 @inline Window(A::AbstractArray) = Window{(size(A, 1) - 1) ÷ 2}()
 
-@inline _setbuffer(::Window{R}, buf::B2) where {R,B2} = Window{R,B2}(buf)
+@inline _setbuffer(::Window{R,L}, buf::B2) where {R,L,B2} = Window{R,L,B2}(buf)
 
 """
 Abstract supertype for kernel neighborhoods.
@@ -103,20 +100,29 @@ Abstract supertype for kernel neighborhoods.
 These can wrap any other neighborhood object, and include a kernel of 
 the same length and positions as the neighborhood.
 """
-abstract type AbstractKernel{R} <: Neighborhood{R} end
+abstract type AbstractKernel{R,L} <: Neighborhood{R,L} end
 
 neighborhood(hood::AbstractKernel) = hood.neighborhood
 neighbors(hood::AbstractKernel) = neighbors(neighborhood(hood))
+offsets(hood::AbstractKernel) = offsets(neighborhood(hood))
+positions(hood::AbstractKernel, I) = positions(neighborhood(hood), I)
 kernel(hood::AbstractKernel) = hood.kernel
-
-Base.length(hood::AbstractKernel) = length(neighborhood(hood))
 
 # We override dot for AbstractKernel as we always mean the sum of the 
 # products of the kernel and buffer values - never a nested dot product.
-function LinearAlgebra.dot(hood::AbstractKernel{R}) where R
-    sum = zero(eltype(kernel(hood)))
-    @simd for i in 1:length(hood) 
-        @inbounds sum += kernel(hood)[i] * neighbors(hood)[i]
+LinearAlgebra.dot(hood::AbstractKernel) = _dot(neighborhood(hood), kernel(hood))
+
+function _dot(hood, kernel)
+    sum = zero(first(neighbors(hood)))
+    for (n, k) in zip(neighbors(hood), kernel)
+        sum += n * k
+    end
+    sum
+end
+function _dot(hood::Window{<:Any,L}, kernel) where L
+    sum = zero(first(neighbors(hood)))
+    @simd for i in 1:L
+        @inbounds sum += _buffer(hood)[i] * kernel[i] 
     end
     sum
 end
@@ -129,25 +135,23 @@ the same length and positions as the neighborhood.
 
 `R = 1` gives 3x3 matrices.
 """
-struct Kernel{R,N,K} <: AbstractKernel{R}
+struct Kernel{R,L,N,K} <: AbstractKernel{R,L}
     neighborhood::N
     kernel::K
 end
 @inline Kernel(A::AbstractMatrix) = Kernel(Window(A), A)
-@inline function Kernel(hood::N, kernel::K) where {N<:Neighborhood{R},K} where R
+@inline function Kernel(hood::N, kernel::K) where {N<:Neighborhood{R,L},K} where {R,L}
     length(hood) == length(kernel) || _kernel_length_error(hood, kernel)
-    Kernel{R,N,K}(hood, kernel)
+    Kernel{R,L,N,K}(hood, kernel)
 end
 
 @noinline _kernel_length_error(hood, kernel) =
     throw(ArgumentError("Neighborhood length $(length(hood)) does not match kernel length $(length(kernel))"))
 
-@inline function _setbuffer(n::Kernel{R,<:Any,K}, buf) where {R,K}
+@inline function _setbuffer(n::Kernel{R,L,<:Any,K}, buf) where {R,L,K}
     hood = _setbuffer(neighborhood(n), buf)
-    Kernel{R,typeof(hood),K}(hood, kernel(n))
+    Kernel{R,L,typeof(hood),K}(hood, kernel(n))
 end
-
-@inline ConstructionBase.constructorof(::Type{Kernel{R,N,K}}) where {R,N,K} = Kernel{R}
 
 """
 Neighborhoods are tuples or vectors of custom coordinates tuples
@@ -155,7 +159,7 @@ that are specified in relation to the central point of the current cell.
 They can be any arbitrary shape or size, but should be listed in column-major
 order for performance.
 """
-abstract type AbstractPositional{R} <: Neighborhood{R} end
+abstract type AbstractPositional{R,L} <: Neighborhood{R,L} end
 
 const CustomOffset = Tuple{Vararg{Int}}
 const CustomOffsets = Union{AbstractArray{<:CustomOffset},Tuple{Vararg{<:CustomOffset}}}
@@ -173,29 +177,30 @@ For simplicity the buffer read from the main grid is a square with sides
 `2r + 1` around the central point, and is not shrunk or offset to match the
 coordinates if they are not symmetrical.
 """
-struct Positional{R,O<:CustomOffsets,B} <: AbstractPositional{R}
+struct Positional{R,L,O<:CustomOffsets,B} <: AbstractPositional{R,L}
     "A tuple of tuples of Int, containing 2-D coordinates relative to the central point"
     offsets::O
     _buffer::B
 end
 Positional(args::CustomOffset...) = Positional(args)
 Positional(offsets::CustomOffsets, _buffer=nothing) =
-    Positional{_absmaxcoord(offsets)}(offsets, _buffer)
-Positional{R}(offsets::CustomOffsets, _buffer=nothing) where R =
-    Positional{R,typeof(offsets),typeof(_buffer)}(offsets, _buffer)
+    Positional{_absmaxcoord(offsets),length(offsets)}(offsets, _buffer)
+Positional{R,L}(offsets::O, _buffer::B=nothing) where {R,L,O<:CustomOffsets,B} =
+    Positional{R,L,O,B}(offsets, _buffer)
 
 # Calculate the maximum absolute value in the offsets to use as the radius
 _absmaxcoord(offsets::Union{AbstractArray,Tuple}) = maximum(map(x -> maximum(map(abs, x)), offsets))
-_absmaxcoord(neighborhood::Positional) = absmaxcoord(offsets(neighborhood))
 
-ConstructionBase.constructorof(::Type{Positional{R,C,B}}) where {R,C,B} = Positional{R}
+ConstructionBase.constructorof(::Type{Positional{R,L,C,B}}) where {R,L,C,B} = 
+    Positional{R,L}
 
 Base.length(hood::Positional) = length(offsets(hood))
 
 offsets(hood::Positional) = hood.offsets
 @inline neighbors(hood::Positional) =
     (_buffer(hood)[(offset .+ radius(hood) .+ 1)...] for offset in offsets(hood))
-@inline set_buffer(n::Positional{R,O}, buf::B2) where {R,O,B2} = Positional{R,O,B2}(offsets(n), buf)
+@inline _setbuffer(n::Positional{R,L,O}, buf::B2) where {R,L,O,B2} = 
+    Positional{R,L,O,B2}(offsets(n), buf)
 
 """
     LayeredPositional(layers::Positional...)
@@ -205,26 +210,25 @@ Sets of [`Positional`](@ref) neighborhoods that can have separate rules for each
 `neighbors` for `LayeredPositional` returns a tuple of iterators
 for each neighborhood layer.
 """
-struct LayeredPositional{R,L,B} <: AbstractPositional{R}
+struct LayeredPositional{R,L,La,B} <: AbstractPositional{R,L}
     "A tuple of custom neighborhoods"
-    layers::L
+    layers::La
     _buffer::B
 end
-LayeredPositional(layers::Positional...) =
-    LayeredPositional(layers)
+LayeredPositional(layers::Positional...) = LayeredPositional(layers)
 LayeredPositional(layers::Tuple{Vararg{<:Positional}}, _buffer=nothing) =
-    LayeredPositional{maximum(map(radius, layers))}(layers, _buffer)
-LayeredPositional{R}(layers, _buffer) where R = begin
-    # Child layers must have the same _buffer
-    layers = map(l -> (@set l._buffer = _buffer), layers)
-    LayeredPositional{R,typeof(layers),typeof(_buffer)}(layers, _buffer)
+    LayeredPositional{maximum(map(radius, layers)),map(length, layers)}(layers, _buffer)
+LayeredPositional{R,L}(layers, _buffer::B) where {R,L,B} = begin
+    # Child layers must have the same _buffer, and the same R and L parameters
+    layers = map(l -> Positional{R,L}(offsets(l), _buffer), layers)
+    LayeredPositional{R,L,typeof(layers),B}(layers, _buffer)
 end
 
 @inline neighbors(hood::LayeredPositional) = map(l -> neighbors(l), hood.layers)
 @inline offsets(hood::LayeredPositional) = map(l -> offsets(l), hood.layers)
 @inline positions(hood::LayeredPositional, args...) = map(l -> positions(l, args...), hood.layers)
-@inline _setbuffer(n::LayeredPositional{R,L}, buf::B2) where {R,L,B2} = 
-    LayeredPositional{R,L,B2}(n.layers, buf)
+@inline _setbuffer(n::LayeredPositional{R,L}, buf) where {R,L} = 
+    LayeredPositional{R,L}(n.layers, buf)
 
 @inline Base.sum(hood::LayeredPositional) = map(sum, neighbors(hood))
 
@@ -252,5 +256,5 @@ end
 Get the size of a neighborhood dimension from its radius,
 which is always 2r + 1.
 """
-@inline hoodsize(hood::Neighborhood) = hoodsize(radius(hood))
+@inline hoodsize(hood::Neighborhood{R}) where R = hoodsize(R)
 @inline hoodsize(radius::Integer) = 2radius + 1

--- a/src/outputs/gif.jl
+++ b/src/outputs/gif.jl
@@ -68,7 +68,7 @@ end
 
 
 _allocgif(i::ImageConfig, e::Extent) = _allocgif(processor(i), i::ImageConfig, e::Extent) 
-function _allocgif(::Processor, i::ImageConfig, e::Extent)
+function _allocgif(::GridProcessor, i::ImageConfig, e::Extent)
     zeros(ARGB32, gridsize(e)..., length(tspan(e)))
 end
 function _allocgif(p::LayoutProcessor, i::ImageConfig, e::Extent)

--- a/src/outputs/graphic.jl
+++ b/src/outputs/graphic.jl
@@ -114,8 +114,6 @@ function showframe(o::GraphicOutput, data)
 end
 showframe(frame::NamedTuple, o::GraphicOutput, data) =
     showframe(first(frame), o, data)
-@noinline showframe(frame::AbstractArray, o::GraphicOutput, data) =
-    error("showframe not defined for $(nameof(typeof(o)))")
 
 function initialise!(o::GraphicOutput, data) 
     initalisegraphics(o, data)

--- a/src/outputs/processors.jl
+++ b/src/outputs/processors.jl
@@ -246,7 +246,7 @@ _valn(vals, n) = vals[n]
 @noinline _grididnotinkeyserror(grid_id, grids) =
     throw(ArgumentError("$grid_id is not in $(keys(grids))"))
 @noinline _wronglengtherror(f, ngrids, n) =
-    throw(ArgumentError("Number of grids ($ngrids) and legtn of $f ($n) must be the same"))
+    throw(ArgumentError("Number of grids ($ngrids) and length of $f ($n) must be the same"))
 
 
 # Automatically choose a processor
@@ -263,7 +263,7 @@ function autoprocessor(init::NamedTuple, scheme, textconfig)
 end
 
 _iterableschemes(::Nothing) = (Greyscale(),)
-_iterableschemes(schemes::Union{Tuple,NamedTuple,AbstractVector}) = schemes
+_iterableschemes(schemes::Union{Tuple,NamedTuple,AbstractArray}) = schemes
 _iterableschemes(scheme) = (scheme,)
 
 

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -37,7 +37,7 @@ function TextConfig(;
         face = FreeTypeAbstraction.findfont(font)
         face isa Nothing && _fontnotfounderror(font)
     else
-        error("$font is not a font name String")
+        _fontnotstring(font)
     end
     TextConfig(face, namepixels, namepos, timepixels, timepos, fcolor, bcolor)
 end
@@ -53,18 +53,20 @@ function autofont()
     return font 
 end
 
+@noinline _fontnotstring(font) = throw(ArgumentError("font $font is not a String"))
+
 @noinline _fontnotfounderror(font) =
     throw(ArgumentError(
         """
-        Font $font can not be found in this system, specify an existing font name `String` 
-        with the `font` keyword, or specify `text=nothing` to display no text."
+        Font "$font" wasn't be found in this system. Specify an existing font name 
+        with the `font` keyword, or use `text=nothing` to display no text."
         """
     ))
 @noinline _nodefaultfonterror(font) =
     error(
         """
-        Your system does not contain the default font $font. Specify font by passing a font
-        name `String` to the keyword argument `font` for the `Output` or `ImageConfig`.
+        Your system does not contain the default font $font. Specify an existing font 
+        name `String` with the keyword-argument `font`, for the `Output` or `ImageConfig`.
         """
     )
 

--- a/src/precalc.jl
+++ b/src/precalc.jl
@@ -1,7 +1,6 @@
 # We have to keep the original rulset pointer as it may be modified 
 # elsewhere like in an Interact.jl interface. `Ruleset` is mutable,
 # and rules has an abstract field type.
-precalcrules(simdata::Vector, rules::Tuple) = map(sd -> precalcrules(sd, rules), simdata)
 function precalcrules(sd::SimData, rules::Tuple)
     @set sd.ruleset = ModelParameters.setparent(
         ruleset(sd),

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -452,9 +452,8 @@ struct SetNeighbors{R,W,F,N} <: SetNeighborhoodRule{R,W}
     "The neighborhood of cells around the central cell"
     neighborhood::N
 end
-SetNeighbors{R,W}(; kwargs...) where {R,W} = _nofunctionerror(SetNeighbors)
-SetNeighbors{R,W}(f; neighborhood=Moore(1)) where {R,W} =
-    SetNeighbors{R,W}(f, neighborhood)
+SetNeighbors{R,W}(; kw...) where {R,W} = _nofunctionerror(SetNeighbors)
+SetNeighbors{R,W}(f; neighborhood=Moore(1)) where {R,W} = SetNeighbors{R,W}(f, neighborhood)
 
 @inline function applyrule!(data, rule::SetNeighbors, read, I)
     let data=data, hood=neighborhood(rule), I=I, rule=rule, read=_astuple(rule, read)
@@ -493,19 +492,10 @@ struct Convolution{R,W,N} <: NeighborhoodRule{R,W}
 end
 Convolution{R,W}(A::AbstractArray) where {R,W} = Convolution{R,W}(Kernel(SMatrix{size(A)...}(A)))
 Convolution{R,W}(; neighborhood) where {R,W} = Convolution{R,W}(neighborhood)
-ConstructionBase.constructorof(::Type{Convolution{R,W}}) where {R,W} = Convolution{R,W}
 
 @inline function applyrule(data, rule::Convolution, read, I)
     @inbounds neighbors(rule) ⋅ kernel(neighborhood(rule))
 end
-
-"""
-    method(rule)
-
-Get the method of a `Cell`, `Neighbors`, or `SetCell` rule.
-"""
-method(rule::Union{Cell,Neighbors,SetCell,SetNeighbors,SetGrid}) = rule.f
-
 
 # Utils
 
@@ -514,10 +504,10 @@ method(rule::Union{Cell,Neighbors,SetCell,SetNeighbors,SetGrid}) = rule.f
 
 # Check number of args passed in as we don't get a normal method
 # error because of the splatted args in the default constructor.
-@generated function _checkfields(::Type{T}, args::A) where {T,A<:Tuple}
-    length(fieldnames(T)) == length(fieldnames(A)) ? :(nothing) : :(_fielderror(T, args))
-end
+# @generated function _checkfields(::Type{T}, args::A) where {T,A<:Tuple}
+    # length(fieldnames(T)) == length(fieldnames(A)) ? :(nothing) : :(_fielderror(T, args))
+# end
 
-@noinline function _fielderror(T, args)
-    throw(ArgumentError("$T has $(length(fieldnames(T))) fields: $(fieldnames(T)), you have used $(length(args))"))
-end
+# @noinline function _fielderror(T, args)
+    # throw(ArgumentError("$T has $(length(fieldnames(T))) fields: $(fieldnames(T)), you have used $(length(args))"))
+# end

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -15,7 +15,6 @@ padval(rs::AbstractRuleset) = rs.padval
 radius(set::AbstractRuleset) = radius(rules(set))
 
 Base.step(rs::AbstractRuleset) = timestep(rs)
-Base.copy(rs::T) where T<:AbstractRuleset = T(rules(rs), boundary(rs), opt(rs), cellsize(rs), timestep(rs))
 
 # ModelParameters interface
 Base.parent(rs::AbstractRuleset) = rules(rs)
@@ -49,12 +48,13 @@ Base.@kwdef mutable struct Ruleset{B<:Boundary,P<:Processor,Op<:PerformanceOpt,C
     timestep::T                  = nothing
     padval::PV                   = 0
 end
-Ruleset(rules::Vararg{<:Rule}; kwargs...) = Ruleset(; rules=rules, kwargs...)
-Ruleset(rules::Tuple; kwargs...) = Ruleset(; rules=rules, kwargs...)
-Ruleset(rs::AbstractRuleset) =
+Ruleset(rules::Rule...; kw...) = Ruleset(; rules=rules, kw...)
+Ruleset(rules::Tuple; kw...) = Ruleset(; rules=rules, kw...)
+function Ruleset(rs::AbstractRuleset)
     Ruleset(
         rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs), padval(rs)
     )
+end
 
 struct StaticRuleset{R<:Tuple,B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T,PV} <: AbstractRuleset
     # Rules are intentionally not type stable. This allows `precalc` and Interact.jl
@@ -67,7 +67,8 @@ struct StaticRuleset{R<:Tuple,B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T,PV
     timestep::T
     padval::PV
 end
-StaticRuleset(rs::AbstractRuleset) =
+function StaticRuleset(rs::AbstractRuleset)
     StaticRuleset(
         rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs), padval(rs)
     )
+end

--- a/src/sequencerules.jl
+++ b/src/sequencerules.jl
@@ -12,13 +12,6 @@ TODO: use the new threading method.
 function sequencerules!(simdata::AbstractSimData)
     sequencerules!(simdata, rules(simdata))
 end
-function sequencerules!(data::AbstractVector{T}) where T<:AbstractSimData
-    newdata = copy(data)
-    Threads.@threads for i in 1:length(data)
-        newdata[i] = sequencerules!(data[i])
-    end
-    newdata
-end
 function sequencerules!(simdata::AbstractSimData, rules::Tuple)
     # Run the first rules
     simdata = maprule!(simdata, rules[1])

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -93,7 +93,9 @@ end
 
 @testset "NeighborhoodRule, CellRule chain" begin
 
-    hoodrule = Neighbors{:a,:a}() do neighborhodhood, cell
+    buf = reshape(1:9, 3, 3)
+    hood = Moore{1}(buf)
+    hoodrule = Neighbors{:a,:a}(hood) do neighborhodhood, cell
         sum(neighborhodhood)
     end
 
@@ -121,6 +123,8 @@ end
 
     chain = Chain(hoodrule, rule)
     @test radius(chain) === 1
+    @test neighborhood(chain) == hood
+    @test Tuple(neighbors(chain)) === (1, 2, 3, 4, 6, 7, 8, 9) 
     @test neighborhoodkey(chain) === :a
     @test rules(Base.tail(chain)) === (rule,)
     @test chain[1] === first(chain) === hoodrule

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -1,4 +1,4 @@
-using DynamicGrids, Setfield, Test
+using DynamicGrids, Setfield, Test, LinearAlgebra, StaticArrays
 import DynamicGrids: SimData, Extent, WritableGridData, 
        radius, dest, hoodsize, neighborhoodkey, _buffer
 
@@ -10,70 +10,110 @@ import DynamicGrids: SimData, Extent, WritableGridData,
             0 0 0 0 1 1
             0 1 0 1 1 0]
 
-    moore = Moore{1}(init[1:3, 1:3])
+    buf1 = [0 0 0
+            0 1 0
+            0 0 0]
+    buf2 = [1 1 1
+            1 0 1
+            1 1 1]
+    buf3 = [1 1 1
+            0 0 1
+            0 0 1]
 
-    @test _buffer(moore) == init[1:3, 1:3]
-    @test hoodsize(moore) == 3
-    @test moore[2, 2] == 0
-    @test length(moore) == 8
-    @test eltype(moore) == Int
-    @test neighbors(moore) isa Base.Generator
-    @test collect(neighbors(moore)) == [0, 1, 0, 0, 1, 0, 1, 1]
-    @test sum(moore) == sum(neighbors(moore)) == 4
-    @test Tuple(offsets(moore)) == ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 0), 
-                                    (0, 1), (1, -1), (1, 0), (1, 1))
-    vonneumann = VonNeumann(1, init[1:3, 1:3])
-    @test offsets(vonneumann) == ((0, -1), (-1, 0), (1, 0), (0, 1))
-    @test _buffer(vonneumann) == init[1:3, 1:3]
-    @test hoodsize(vonneumann) == 3
-    @test vonneumann[2, 1] == 1
-    @test length(vonneumann) == 4
-    @test eltype(vonneumann) == Int
-    @test neighbors(vonneumann) isa Base.Generator
-    @test collect(neighbors(vonneumann)) == [1, 0, 1, 1]
-    @test sum(neighbors(vonneumann)) == 3
-    vonneumann2 = VonNeumann(2)
-    @test offsets(vonneumann2) == 
-       ((0, -2), (-1, -1), (0, -1), (1, -1), 
-         (-2 , 0), (-1, 0), (1, 0), (2, 0), 
-         (-1, 1), (0, 1), (1, 1), (0, 2))
+    @testset "Moore" begin
+        moore = Moore{1}(init[1:3, 1:3])
+        @test _buffer(moore) == init[1:3, 1:3]
+        @test hoodsize(moore) == 3
+        @test moore[2, 2] == 0
+        @test length(moore) == 8
+        @test eltype(moore) == Int
+        @test neighbors(moore) isa Base.Generator
+        @test collect(neighbors(moore)) == [0, 1, 0, 0, 1, 0, 1, 1]
+        @test sum(moore) == sum(neighbors(moore)) == 4
+        @test Tuple(offsets(moore)) == ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 0), 
+                                        (0, 1), (1, -1), (1, 0), (1, 1))
 
-    buf = [0 0 0
-           0 1 0
-           0 0 0]
-    @test sum(Moore{1}(buf)) == 0
-    @test sum(VonNeumann(1, buf)) == 0
+        moore1 = @set moore._buffer = buf1
+        @test moore1._buffer == buf1
+        moore2 = DynamicGrids._setbuffer(moore, buf2)
+        @test moore2._buffer == buf2
 
-    buf = [1 1 1
-           1 0 1
-           1 1 1]
-    @test sum(Moore{1}(buf)) == 8
-    @test sum(VonNeumann(1, buf)) == 4
+        @test sum(Moore{1}(buf1)) == 0
+        @test sum(Moore{1}(buf2)) == 8
+        @test sum(Moore{1}(buf3)) == 5
+    end
+    @testset "Window" begin
+        window = Window{1}(init[1:3, 1:3])
+        @test _buffer(window) == init[1:3, 1:3]
+        @test hoodsize(window) == 3
+        @test window[2, 2] == 0
+        @test length(window) == 9
+        @test eltype(window) == Int
+        @test neighbors(window) isa Array 
+        @test neighbors(window) == _buffer(window)
+        @test sum(window) == sum(neighbors(window)) == 4
+        @test Tuple(offsets(window)) == ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 0), 
+                                        (0, 1), (1, -1), (1, 0), (1, 1))
 
-    buf = [1 1 1
-           0 0 1
-           0 0 1]
-    @test sum(Moore(1, buf)) == 5
-    @test sum(VonNeumann(1, buf)) == 2
+        window1 = @set window._buffer = buf1
+        @test window1._buffer == buf1
+        window2 = DynamicGrids._setbuffer(window, buf2)
+        @test window2._buffer == buf2
 
-    buf = [0 1 0 0 1
-           0 0 1 0 0
-           0 0 0 1 1
-           0 0 1 0 1
-           1 0 1 0 1]
-    state = buf[3, 3]
-    custom1 = Positional(((-1,-1), (2,-2), (2,2), (-1,2), (0,0)), buf)
-    custom2 = Positional(((-1,-1), (0,-1), (1,-1), (2,-1), (0,0)), buf)
-    layered = LayeredPositional(
-        (Positional((-1,1), (-2,2)), Positional((1,2), (2,2))), buf)
+        @test sum(Window{1}(buf1)) == 1
+        @test sum(Window{1}(buf2)) == 8
+        @test sum(Window{1}(buf3)) == 5
+    end
+    @testset "VonNeumann/Positional" begin
+        vonneumann = VonNeumann(1, init[1:3, 1:3])
+        @test offsets(vonneumann) == ((0, -1), (-1, 0), (1, 0), (0, 1))
+        @test _buffer(vonneumann) == init[1:3, 1:3]
+        @test hoodsize(vonneumann) == 3
+        @test vonneumann[2, 1] == 1
+        @test length(vonneumann) == 4
+        @test eltype(vonneumann) == Int
+        @test neighbors(vonneumann) isa Base.Generator
+        @test collect(neighbors(vonneumann)) == [1, 0, 1, 1]
+        @test sum(neighbors(vonneumann)) == 3
+        vonneumann2 = VonNeumann(2)
+        @test offsets(vonneumann2) == 
+           ((0, -2), (-1, -1), (0, -1), (1, -1), 
+             (-2 , 0), (-1, 0), (1, 0), (2, 0), 
+             (-1, 1), (0, 1), (1, 1), (0, 2))
 
-    @test neighbors(custom1) isa Base.Generator
-    @test collect(neighbors(custom1)) == [0, 1, 1, 0, 0]
+        vonneumann1 = @set vonneumann._buffer = buf2
+        @test vonneumann1._buffer == buf2
+        vonneumann2 = DynamicGrids._setbuffer(vonneumann, buf3)
+        @test vonneumann2._buffer == buf3
 
-    @test sum(custom1) == 2
-    @test sum(custom2) == 0
-    @test sum(layered) == (1, 2)
-    @test offsets(layered) == (((-1, 1), (-2, 2)), ((1, 2), (2, 2)))
+        @test sum(VonNeumann(1, buf1)) == 0
+        @test sum(VonNeumann(1, buf2)) == 4
+        @test sum(VonNeumann(1, buf3)) == 2
+    end
+    @testset "Layered/Positional" begin
+        buf = [0 1 0 0 1
+               0 0 1 0 0
+               0 0 0 1 1
+               0 0 1 0 1
+               1 0 1 0 1]
+        custom1 = Positional(((-1,-1), (2,-2), (2,2), (-1,2), (0,0)), buf)
+        custom2 = Positional(((-1,-1), (0,-1), (1,-1), (2,-1), (0,0)), buf)
+        layered = LayeredPositional(
+            (Positional((-1,1), (-2,2)), Positional((1,2), (2,2))), buf)
+
+        @test neighbors(custom1) isa Base.Generator
+        @test collect(neighbors(custom1)) == [0, 1, 1, 0, 0]
+
+        @test sum(custom1) == 2
+        @test sum(custom2) == 0
+        @test sum(layered) == (1, 2)
+        @test offsets(layered) == (((-1, 1), (-2, 2)), ((1, 2), (2, 2)))
+
+        layered1 = @set layered._buffer = 2buf
+        @test layered1._buffer == 2buf
+        layered2 = DynamicGrids._setbuffer(layered, 3buf)
+        @test layered2._buffer == 3buf
+    end
     @testset "neighbors works on rule" begin
         rule = Life(;neighborhood=Moore{1}([0 1 1; 0 0 0; 1 1 1]))
         @test sum(neighbors(rule)) == 5
@@ -81,11 +121,28 @@ import DynamicGrids: SimData, Extent, WritableGridData,
 
 end
 
+@testset "Kernel" begin
+    buf = reshape(1:9, 3, 3)
+    @testset "Window" begin
+        k = Kernel(Window{1,9,typeof(buf)}(buf), SMatrix{3,3}(reshape(1:9, 3, 3)))
+        @test dot(k) == sum((1:9).^2)
+    end
+    @testset "Moore" begin
+        k = Kernel(Moore{1,8,typeof(buf)}(buf), (1:4..., 6:9...))
+        @test dot(k) == sum((1:4).^2) + sum((6:9).^2)
+    end
+    @testset "Positional" begin
+        off = ((0,-1),(-1,0),(1,0),(0,1))
+        hood = Positional{1,4,typeof(off),typeof(buf)}(off, buf)
+        k = Kernel(hood, 1:4)
+        @test dot(k) == 1 * 2 + 2 * 4 + 3 * 6 + 4 * 8
+    end
+end
+
 struct TestNeighborhoodRule{R,W,N} <: NeighborhoodRule{R,W}
     neighborhood::N
 end
-DynamicGrids.applyrule(data, rule::TestNeighborhoodRule, state, index) =
-    state
+DynamicGrids.applyrule(data, rule::TestNeighborhoodRule, state, index) = state
 
 struct TestSetNeighborhoodRule{R,W,N} <: SetNeighborhoodRule{R,W}
     neighborhood::N

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -1,22 +1,37 @@
-using DynamicGrids, Test
-using DynamicGrids: isshowable, frameindex, storeframe!, SimData
+using DynamicGrids, DimensionalData, Dates, Test
+using DynamicGrids: isshowable, frameindex, storeframe!, SimData, stoppedframe
 
 # Mostly outputs are tested in integration.jl
 @testset "Output construction" begin
     init = [10.0 11.0
             0.0   5.0]
 
-    output1 = ArrayOutput(init; tspan=1:1)
+    output = ArrayOutput(init; tspan=Date(2001):Year(1):Date(2010))
     ruleset = Ruleset(Life())
 
-    @test frameindex(output1, 5) == 5 
-    @test isshowable(output1, 5) == false
+    @test length(output) == 10
+    @test size(output) == (10,)
+    @test step(output) == Year(1)
+    @test stoppedframe(output) == 10
+    @test timestep(output) == Year(1)
+    @test_throws ArgumentError DynamicGrids.ruleset(output)
+    @test frameindex(output, 5) == 5 
+    @test isshowable(output, 5) == false
+    @test output[1] == output[Ti(1)] == init
 
-    # Test pushing new frames to an output
-    update = [8.0 15.0;
-              2.0  9.0]
-    @test length(output1) == 1
-    push!(output1, update)
-    @test length(output1) == 2
-    @test output1[2] == update
+    @testset "DimensionalData interface" begin
+        @test output isa AbstractDimArray{<:Array,1,<:Tuple{<:Ti}}
+        @test dims(output) isa Tuple{<:Ti}
+        @test name(output) == NoName()
+        @test metadata(output) == NoMetadata()
+        da = output[Ti(Between(Date(2002), Date(2003)))]
+        @test da isa DimArray{<:Array,1,<:Tuple{<:Ti}}
+        @test index(da) == (Date(2002):Year(1):Date(2002),)
+    end
+
+    @testset "errors" begin
+        @test_throws UndefKeywordError ArrayOutput(ones(5, 5))
+        @test_throws ArgumentError ArrayOutput((a=ones(5, 5), b=ones(4, 4)); tspan=1:10)
+        @test_throws ArgumentError ArrayOutput(ones(5, 5); mask=ones(2, 2), tspan=1:10)
+    end
 end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -65,7 +65,8 @@ end
 @testset "Convolution" begin
     k = SA[1 0 1; 0 0 0; 1 0 1]
     buf = SA[1 0 0; 0 0 1; 0 0 1]
-    rule = Convolution(Kernel(k, buf))
+    hood = Window{1,typeof(buf)}(buf)
+    rule = Convolution(Kernel(hood, k))
     @test applyrule(nothing, rule, 0, (3, 3)) == k ⋅ buf
     output = ArrayOutput(init; tspan=1:2)
     sim!(output, rule)


### PR DESCRIPTION
Generalises `Kernel` neighborhoods to wrap any other kind of neighborhood. Also defines `dot` so that it works on the kernel for any neighborhood, without iteratively applying `dot` to the contents.

The contents of the grid always behave as scalars, not vectors. Even if they are actually vectors like `SArray`.

Also, closes #95 and closes #97 by defining `dot` for `AbstractKernel`, that treats grid contents as scalars.