### PR TITLE
move padval to Extent

### DIFF
--- a/src/extent.jl
+++ b/src/extent.jl
@@ -29,6 +29,7 @@ to `Output` constructors instead of `init`, `mask`, `aux` and `tspan`.
 - `mask`: `BitArray` for defining cells that will/will not be run.
 - `aux`: NamedTuple of arbitrary input data. Use `aux(data, Aux(:key))` to access from 
   a `Rule` in a type-stable way.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
 - `tspan`: Time span range. Never type-stable, only access this in `precalc` methods
 """
 mutable struct Extent{I<:Union{AbstractArray,NamedTuple},

--- a/src/framework.jl
+++ b/src/framework.jl
@@ -77,11 +77,10 @@ function sim!(output::Output, rules::Rule...;
     opt=NoOpt(),
     cellsize=1,
     timestep=nothing,
-    padval=0,
     kwargs...
 )
     ruleset = Ruleset(rules...;
-        boundary=boundary, proc=proc, opt=opt, cellsize=cellsize, timestep=timestep, padval=padval
+        boundary=boundary, proc=proc, opt=opt, cellsize=cellsize, timestep=timestep, 
     )
     return sim!(output::Output, ruleset; kwargs...)
 end

--- a/src/outputs/array.jl
+++ b/src/outputs/array.jl
@@ -1,5 +1,5 @@
 """
-    ArrayOutput(init; tspan::AbstractRange) 
+    ArrayOutput(init; tspan::AbstractRange, [aux, mask, padval]) 
 
 A simple output that stores each step of the simulation in a vector of arrays.
 
@@ -8,6 +8,10 @@ A simple output that stores each step of the simulation in a vector of arrays.
 
 ## Keyword Argument:
 - `tspan`: `AbstractRange` timespan for the simulation
+- `aux`: NamedTuple of arbitrary input data. Use `get(data, Aux(:key), I...)` 
+  to access from a `Rule` in a type-stable way.
+- `mask`: `BitArray` for defining cells that will/will not be run.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
 """
 mutable struct ArrayOutput{T,F<:AbstractVector{T},E} <: Output{T,F} 
     frames::F
@@ -20,7 +24,7 @@ function ArrayOutput(; frames, running, extent, kwargs...)
 end
 
 """
-    ResultOutput(init; tspan::AbstractRange) 
+    ResultOutput(init; tspan::AbstractRange, [aux, mask, padval]) 
 
 A simple output that only stores the final result, not intermediate frames.
 
@@ -29,6 +33,10 @@ A simple output that only stores the final result, not intermediate frames.
 
 ## Keyword Argument:
 - `tspan`: `AbstractRange` timespan for the simulation
+- `mask`: `BitArray` for defining cells that will/will not be run.
+- `aux`: NamedTuple of arbitrary input data. Use `get(data, Aux(:key), I...)` 
+  to access from a `Rule` in a type-stable way.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
 """
 mutable struct ResultOutput{T,F<:AbstractVector{T},E} <: Output{T,F} 
     frames::F

--- a/src/outputs/gif.jl
+++ b/src/outputs/gif.jl
@@ -29,8 +29,9 @@ end
 
 
 """
-    GifOutput(init; 
-        filename, tspan, fps=25.0, store=false, 
+    GifOutput(init; filename, tspan::AbstractRange, 
+        aux=nothing, mask=nothing, padval=zero(eltype(init)),
+        fps=25.0, store=false, 
         font=autofont(),
         scheme=Greyscale()
         text=TextConfig(; font=font),
@@ -39,6 +40,22 @@ end
     )
 
 Output that stores the simulation as images and saves a Gif file on completion.
+
+## Arguments:
+- `init`: initialisation `Array` or `NamedTuple` of `Array`
+
+## Keyword Argument:
+- `tspan`: `AbstractRange` timespan for the simulation
+- `aux`: NamedTuple of arbitrary input data. Use `get(data, Aux(:key), I...)` 
+  to access from a `Rule` in a type-stable way.
+- `mask`: `BitArray` for defining cells that will/will not be run.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
+- `font`: `String` font name
+- `scheme`: ColorSchemes.jl scheme, or `Greyscale()`
+- `text`: [`TextConfig`](@ref) object or `nothing`.
+- `processor`: [`GridProcessor`](@ref)
+- `minval`: minimum value(s) to set colour maximum
+- `maxval`: maximum values(s) to set colour minimum
 """
 mutable struct GifOutput{T,F<:AbstractVector{T},E,GC,IC,G,N} <: ImageOutput{T,F}
     frames::F

--- a/src/outputs/repl.jl
+++ b/src/outputs/repl.jl
@@ -5,7 +5,8 @@ struct Block <: CharStyle end
 struct Braile <: CharStyle end
 
 """
-    REPLOutput(init; tspan, fps=25.0, store=false, color=:white, cutoff=0.5, style=Block())
+    REPLOutput(init; tspan, aux=nothing, mask=nothing, padval=zero(eltype(init)), 
+        fps=25.0, store=false, color=:white, cutoff=0.5, style=Block())
 
 An output that is displayed directly in the REPL. It can either store or discard
 simulation frames.
@@ -15,11 +16,15 @@ simulation frames.
 
 ### Keyword Arguments:
 - `tspan`: `AbstractRange` timespan for the simulation
-- `fps::Real`: frames per second to display the simulation
-- `store::Bool`: whether ot store the simulation frames for later use
+- `mask`: `BitArray` for defining cells that will/will not be run.
+- `aux`: `NamedTuple` of arbitrary input data. Use `get(data, Aux(:key), I...)` 
+  to access from a `Rule` in a type-stable way.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
+- `fps`: `Real` frames per second to display the simulation
+- `store`: `Bool` whether ot store the simulation frames for later use
 - `color`: a color from Crayons.jl
-- `cutoff::Real`: the cutoff point to display a full or empty cell. Default is `0.5`
-- `style::CharStyle`: `Block()` or `Braile()` style printing. `Braile` uses 1/4 the screen space.
+- `cutoff`: `Real` cutoff point to display a full or empty cell. Default is `0.5`
+- `style`: `CharStyle` `Block()` or `Braile()` printing. `Braile` uses 1/4 the screen space of `Block`.
 
 ```julia
 REPLOutput(init)

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -11,7 +11,6 @@ proc(rs::AbstractRuleset) = rs.proc
 opt(rs::AbstractRuleset) = rs.opt
 cellsize(rs::AbstractRuleset) = rs.cellsize
 timestep(rs::AbstractRuleset) = rs.timestep
-padval(rs::AbstractRuleset) = rs.padval
 radius(set::AbstractRuleset) = radius(rules(set))
 
 Base.step(rs::AbstractRuleset) = timestep(rs)
@@ -37,7 +36,7 @@ Rules will be run in the order they are passed, ie. `Ruleset(rule1, rule2, rule3
 - `timestep`: fixed timestep where this is reuired for some rules.
   eg. `Month(1)` or `1u"s"`.
 """
-Base.@kwdef mutable struct Ruleset{B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T,PV} <: AbstractRuleset
+Base.@kwdef mutable struct Ruleset{B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T} <: AbstractRuleset
     # Rules are intentionally not type stable. This allows `precalc` and Interact.jl
     # updates to change the rule type. Function barriers remove most performance overheads.
     rules::Tuple{Vararg{<:Rule}} = ()
@@ -46,17 +45,16 @@ Base.@kwdef mutable struct Ruleset{B<:Boundary,P<:Processor,Op<:PerformanceOpt,C
     opt::Op                      = NoOpt()
     cellsize::C                  = 1
     timestep::T                  = nothing
-    padval::PV                   = 0
 end
 Ruleset(rules::Rule...; kw...) = Ruleset(; rules=rules, kw...)
 Ruleset(rules::Tuple; kw...) = Ruleset(; rules=rules, kw...)
 function Ruleset(rs::AbstractRuleset)
     Ruleset(
-        rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs), padval(rs)
+        rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs),
     )
 end
 
-struct StaticRuleset{R<:Tuple,B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T,PV} <: AbstractRuleset
+struct StaticRuleset{R<:Tuple,B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T} <: AbstractRuleset
     # Rules are intentionally not type stable. This allows `precalc` and Interact.jl
     # updates to change the rule type. Function barriers remove most performance overheads.
     rules::R
@@ -65,10 +63,9 @@ struct StaticRuleset{R<:Tuple,B<:Boundary,P<:Processor,Op<:PerformanceOpt,C,T,PV
     opt::Op
     cellsize::C
     timestep::T
-    padval::PV
 end
 function StaticRuleset(rs::AbstractRuleset)
     StaticRuleset(
-        rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs), padval(rs)
+        rules(rs), boundary(rs), proc(rs), opt(rs), cellsize(rs), timestep(rs),
     )
 end

--- a/src/simulationdata.jl
+++ b/src/simulationdata.jl
@@ -63,9 +63,9 @@ function SimData(extent::AbstractExtent{<:NamedTuple{Keys}}, ruleset::AbstractRu
     y, x = gridsize(extent)
     radii = NamedTuple{Keys}(get(radius(ruleset), key, 0) for key in Keys)
     # Construct the SimData for each grid
-    grids = map(init(extent), radii) do in, r
+    grids = map(init(extent), radii, padval(extent)) do in, r, pv
         ReadableGridData{y,x,r}(
-            in, mask(extent), proc(ruleset), opt(ruleset), boundary(ruleset), padval(ruleset)
+            in, mask(extent), proc(ruleset), opt(ruleset), boundary(ruleset), pv 
         )
     end
     SimData(grids, extent, ruleset)
@@ -107,7 +107,7 @@ currentframe(d::SimData) = d.currentframe
 currenttime(d::SimData) = tspan(d)[currentframe(d)]
 
 # Getters forwarded to data
-Base.getindex(d::SimData, i::Symbol) = getindex(grids(d), i)
+Base.getindex(d::SimData, key::Symbol) = getindex(grids(d), key)
 
 """
     Base.get(data::SimData, keyorval, I...)
@@ -134,7 +134,7 @@ gridsize(d::SimData) = gridsize(first(d))
 proc(d::SimData) = proc(ruleset(d))
 opt(d::SimData) = opt(ruleset(d))
 boundary(d::SimData) = boundary(ruleset(d))
-padval(d::SimData) = padval(ruleset(d))
+padval(d::SimData) = padval(extent(d))
 rules(d::SimData) = rules(ruleset(d))
 
 # Get the actual current timestep, e.g. seconds instead of variable periods like Month


### PR DESCRIPTION
`padval` pads the border of a grid when that's required. This was one `Ruleset` but that makes no sense, as the default should be `zero(eltype(init))` - which is in `Extent`.