### PR TITLE
standardise inbounds args

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -91,7 +91,7 @@ Add the value `x` to a grid cell.
 ```julia
 function applyrule!(data::SimData, rule::My{A,B}, state, cellindex) where {A,B}
 
-    dest, is_inbounds = inbounds(jump .+ cellindex, gridsize(data))
+    dest, is_inbounds = inbounds(data, (jump .+ cellindex)...)
 
     # Update spotted cell if it's on the grid
     is_inbounds && add!(data[W], state, dest...)
@@ -146,7 +146,8 @@ Set the grid cell `c` to `xor(c, x)`. See `add!` for example usage.
 function xor! end
 
 """
-    inbounds(I::Tuple, data::SimData) -> Tuple{NTuple{2,Int},Bool}
+    inbounds(data::SimData, I::Tuple) -> Tuple{NTuple{2,Int},Bool}
+    inbounds(data::SimData, I...) -> Tuple{NTuple{2,Int},Bool}
 
 Check grid boundaries for a coordinate before writing in [`SetCellRule`](@ref).
 
@@ -162,7 +163,8 @@ wrapped equivalent, and `true` as it is allways in-bounds.
 function inbounds end
 
 """
-    isinbounds(I::Tuple, data) -> Bool
+    isinbounds(data, I::Tuple) -> Bool
+    isinbounds(data, I...) -> Bool
 
 Check that a coordinate is within the grid, usually in [`SetCellRule`](@ref).
 

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -135,7 +135,7 @@ end
         rule = SetCell() do data, I, state
             if state > 0
                 pos = I[1] - 2, I[2]
-                isinbounds(pos, data) && add!(first(data), 1, pos...)
+                isinbounds(data, pos) && add!(first(data), 1, pos...)
             end
         end
         for proc in (SingleCPU(), CPUGPU(), ThreadedCPU()), opt in (NoOpt(), SparseOpt())
@@ -155,7 +155,7 @@ end
         rule = SetCell() do data, I, state
             if state > 0
                 pos = I[1] - 2, I[2]
-                isinbounds(pos, data) && (data[pos...] = 5)
+                isinbounds(data, pos) && (data[pos...] = 5)
             end
         end
         sim!(output, rule)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,38 +1,39 @@
 using DynamicGrids, Test
-using DynamicGrids: inbounds, isinbounds, _cyclic_index, SimData, _unwrap, ismasked
+using DynamicGrids: inbounds, isinbounds, _inbounds, _isinbounds, _cyclic_index, 
+    SimData, _unwrap, ismasked
 
 @testset "boundary boundary checks are working" begin
     @testset "inbounds with Remove() returns index and false for an boundaryed index" begin
-        @test inbounds((1, 1), (4, 5), Remove()) == ((1,1),true)
-        @test inbounds((2, 3), (4, 5), Remove()) == ((2,3),true)
-        @test inbounds((4, 5), (4, 5), Remove()) == ((4,5),true)
-        @test inbounds((-3, -100), (4, 5), Remove()) == ((-3,-100),false)
-        @test inbounds((0, 0), (4, 5), Remove()) == ((0,0),false)
-        @test inbounds((2, 3), (3, 2), Remove()) == ((2,3),false)
-        @test inbounds((2, 3), (1, 4), Remove()) == ((2,3),false)
-        @test inbounds((200, 300), (2, 3), Remove()) == ((200,300),false)
+        @test _inbounds(Remove(), (4, 5), 1, 1) == ((1,1), true)
+        @test _inbounds(Remove(), (4, 5), 2, 3) == ((2,3), true)
+        @test _inbounds(Remove(), (4, 5), 4, 5) == ((4,5), true)
+        @test _inbounds(Remove(), (4, 5), 0, 0) == ((0,0), false)
+        @test _inbounds(Remove(), (3, 2), 2, 3) == ((2,3), false)
+        @test _inbounds(Remove(), (1, 4), 2, 3) == ((2,3), false)
+        @test _inbounds(Remove(), (2, 3), 200, 300) == ((200,300), false)
+        @test _inbounds(Remove(), (4, 5), -3, -100) == ((-3,-100), false)
     end
     @testset "inbounds with Wrap() returns new index and true for an boundaryed index" begin
-        @test inbounds((-2,3), (10, 10), Wrap()) == ((8,3),true)
-        @test inbounds((2,0), (10, 10), Wrap()) == ((2,10),true)
-        @test inbounds((22,0), (10, 10), Wrap()) == ((2,10),true)
-        @test inbounds((-22,0), (10, 10), Wrap()) == ((8,10),true)
+        @test _inbounds(Wrap(), (10, 10),  -2, 3) == ((8,  3), true)
+        @test _inbounds(Wrap(), (10, 10),   2, 0) == ((2, 10), true)
+        @test _inbounds(Wrap(), (10, 10),  22, 0) == ((2, 10), true)
+        @test _inbounds(Wrap(), (10, 10), -22, 0) == ((8, 10), true)
     end
     @testset "isinbounds" begin
-        @test isinbounds((4, 5), (4, 5)) == true
-        @test isinbounds((200, 300), (2, 3)) == false
-        @test isinbounds((-22,0), (10, 10)) == false
+        @test _isinbounds((4, 5), 4, 5) == true
+        @test _isinbounds((2, 3), 200, 300) == false
+        @test _isinbounds((10, 10), -22, 0) == false
     end
     @testset "boundscheck objects" begin
         output = ArrayOutput(zeros(Int, 10, 10); tspan=1:10)
         sd = SimData(output.extent, Ruleset())
-        @test inbounds((5, 5), sd) == ((5, 5), true)
-        @test inbounds((5, 5), first(sd)) == ((5, 5), true)
-        @test inbounds((12, 5), sd) == ((12, 5), false)
+        @test inbounds(sd, 5, 5) == ((5, 5), true)
+        @test inbounds(first(sd),  5, 5) == ((5, 5), true)
+        @test inbounds(sd, 12, 5) == ((12, 5), false)
         sd_wrap = SimData(output.extent, Ruleset(; boundary=Wrap()))
-        @test inbounds((5, 5), sd_wrap) == ((5, 5), true)
-        @test inbounds((12, 5), sd_wrap) == ((2, 5), true)
-        @test inbounds((12, 5), first(sd_wrap)) == ((2, 5), true)
+        @test inbounds(sd_wrap, 5, 5) == ((5, 5), true)
+        @test inbounds(sd_wrap, 12, 5) == ((2, 5), true)
+        @test inbounds(first(sd_wrap), 12, 5) == ((2, 5), true)
     end
 end
 


### PR DESCRIPTION
The argument order was weird for Julia and the rest of the package - indices should be after the object. There were exported methods not in the interface - now prefixed with `_`.