### PR TITLE
add TransformedOutput

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@ using Documenter, DynamicGrids, KernelAbstractions
 makedocs(
     modules = [DynamicGrids],
     sitename = "DynamicGrids.jl",
+    checkdocs = :all,
     strict = true,
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -189,6 +189,7 @@ xor!
 Output
 ArrayOutput
 ResultOutput
+TransformedOutput
 GraphicOutput
 REPLOutput
 ImageOutput

--- a/src/DynamicGrids.jl
+++ b/src/DynamicGrids.jl
@@ -61,7 +61,11 @@ export BoundaryCondition, Remove, Wrap
 
 export ParameterSource, Aux, Grid
 
-export Output, GraphicOutput, ImageOutput, ArrayOutput, ResultOutput, REPLOutput, GifOutput
+export Output, ArrayOutput, ResultOutput, TransformedOutput
+
+export GraphicOutput, REPLOutput
+
+export ImageOutput, GifOutput
 
 export ImageGenerator, Image, Layout, SparseOptInspector
 
@@ -98,6 +102,7 @@ include("outputs/textconfig.jl")
 include("outputs/schemes.jl")
 include("outputs/imagegenerators.jl")
 include("outputs/array.jl")
+include("outputs/transformed.jl")
 include("outputs/repl.jl")
 include("outputs/gif.jl")
 include("framework.jl")

--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -1,0 +1,58 @@
+"""
+    TransformedOutput(f, init; tspan::AbstractRange, kw...) 
+
+An output that stores the result of some function `f` of the grid/s
+
+# Arguments
+
+- `f`: a function or functor that accepts an `AbstractArray` or `NamedTuple` of
+    `AbstractArray` with names matchin `init`. The `AbstractArray` will be a view into 
+    the grid the same size as the init grids, removing any padding that has been added.
+- `init`: initialisation `Array` or `NamedTuple` of `Array`
+
+# Keywords
+
+- `tspan`: `AbstractRange` timespan for the simulation
+- `aux`: NamedTuple of arbitrary input data. Use `get(data, Aux(:key), I...)` 
+    to access from a `Rule` in a type-stable way.
+- `mask`: `BitArray` for defining cells that will/will not be run.
+- `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
+"""
+mutable struct TransformedOutput{T,A<:AbstractVector{T},E,F,B} <: Output{T,A} 
+    frames::A
+    running::Bool
+    extent::E
+    f::F
+    buffer::B
+end
+function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix}; extent=nothing, kw...)
+    extent = extent isa Nothing ? Extent(; init=init, kw...) : extent
+    buffer = init isa NamedTuple ? map(zero, init) : zero(init)
+    frames = append!([f(init)], map(_ -> f(buffer), tspan(extent)))
+    TransformedOutput(frames, false, extent, f, buffer)
+end
+function TransformedOutput(init; kw...)
+    throw(ArgumentError("TransformedOutput must be passed a function and the init grid(s) as arguments"))
+end
+
+function storeframe!(o::TransformedOutput, data::AbstractSimData) 
+    o[frameindex(o, data)] = _store_x(o, grids(data))
+end
+
+function _store_x(o::TransformedOutput, grids::NamedTuple)
+    # Make a new named tuple of raw arrays without wrappers, copying
+    # to the buffer where an OffsetArray was used for padding
+    # Often it's faster to copy than use a view when f is sum/mean etc
+    nt = map(grids, o.buffer) do g, b
+        source(g) isa OffsetArray ? copy!(b, g) : parent(source(g))
+    end
+    o.f(nt)
+end
+function _store_x(o::TransformedOutput, grids::NamedTuple{(:_default_,)})
+    g = first(grids)
+    A = source(g) isa OffsetArray ? copy!(o.buffer, g) : parent(source(g))
+    o.f(A)
+end
+
+init_output_grids!(o::TransformedOutput, init) = nothing
+_initdata!(o::TransformedOutput, init) = nothing

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -258,10 +258,24 @@ end
     end
 end
 
-
-@testset "REPLOutput" begin
+@testset "sim! with other outputs" begin
     for proc in (SingleCPU(), ThreadedCPU(), CPUGPU()), opt in (NoOpt(), SparseOpt())
         @testset "$(nameof(typeof(opt))) $(nameof(typeof(proc)))" begin
+            @testset "Transformed output" begin
+                ruleset = Ruleset(Life();
+                    timestep=Month(1),
+                    boundary=Wrap(),
+                    proc=proc,
+                    opt=opt,
+                )
+                tspan_ = Date(2010, 4):Month(1):Date(2010, 7)
+                output = TransformedOutput(sum, test6_7[:init]; tspan=tspan_)
+                sim!(output, ruleset)
+                @test output[1] == sum(test6_7[:init])
+                @test output[2] == sum(test6_7[:test2])
+                @test output[3] == sum(test6_7[:test3])
+                @test output[4] == sum(test6_7[:test4])
+            end
             @testset "REPLOutput block works, in Unitful.jl seconds" begin
                 ruleset = Ruleset(;
                     rules=(Life(),),
@@ -271,7 +285,7 @@ end
                     opt=opt,
                 )
                 output = REPLOutput(test6_7[:init]; 
-                    tspan=0u"s":5u"s":6u"s", style=Block(), fps=100, store=true
+                    tspan=0u"s":5u"s":6u"s", style=Block(), fps=1000, store=true
                 )
                 @test DynamicGrids.isstored(output) == true
                 sim!(output, ruleset)
@@ -289,7 +303,7 @@ end
                     opt=opt,
                 )
                 tspan_ = Date(2010, 4):Month(1):Date(2010, 7)
-                output = REPLOutput(test6_7[:init]; tspan=tspan_, style=Braile(), fps=100, store=false)
+                output = REPLOutput(test6_7[:init]; tspan=tspan_, style=Braile(), fps=1000, store=false)
                 sim!(output, ruleset)
                 @test output[Ti(Date(2010, 7))] == test6_7[:test4]
                 @test DynamicGrids.tspan(output) == Date(2010, 4):Month(1):Date(2010, 7)


### PR DESCRIPTION
`TransformedOutput` lets you transform the output grid/s with a function `f`. 

It has a buffer and copies padded arrays to non-padded, and uses non-padded directly for max performance.

@jamesmaino this is a generalization of the transformed outputs we were using for optimization. Instead of doing that manually, you can do it with a simple function that e.g. sums the grid/s so only the sum is stored, not the whole grid. This uses less ram/cache, so it's faster for optimization.