### PR TITLE
Layout

### DIFF
--- a/src/outputs/image.jl
+++ b/src/outputs/image.jl
@@ -28,9 +28,10 @@ end
 function ImageConfig(init; 
     font=autofont(), text=TextConfig(; font=font), textconfig=text, 
     scheme=ObjectScheme(), 
-    imagegen=autorenderer(init, scheme), renderer=imagegen, 
+    imagegen=nothing, renderer=imagegen,
     minval=nothing, maxval=nothing, kw...
 ) 
+    renderer = renderer isa Nothing ? autorenderer(init, scheme; kw...) : renderer
     imagebuffer = _allocimage(renderer, init)
     ImageConfig(renderer, minval, maxval, imagebuffer, textconfig)
 end

--- a/src/outputs/image.jl
+++ b/src/outputs/image.jl
@@ -9,14 +9,15 @@ Common configuration component for all [`ImageOutput`](@ref).
 
 - `init` output init object, used to generate other arguments automatically.
 - `minval`: Minimum value in the grid(s) to normalise for conversion to an RGB pixel. 
-    Number or `Tuple` for multiple grids. 
+    A `Vector/Matrix` for multiple grids, matching the `layout` array. 
 - `maxval`: Maximum value in the grid(s) to normalise for conversion to an RGB pixel. 
-    Number or `Tuple` for multiple grids. 
+    A `Vector/Matrix` for multiple grids, matching the `layout` array. 
 - `font`: `String` name of font to search for. A default will be guessed.
 - `text`: `TextConfig()` or `nothing` for no text. Default is `TextConfig(; font=font)`.
-- `scheme`: ColorSchemes.jl scheme, or `Greyscale()`. ObjectScheme() by default.
-- `renderer`: [`Renderer`](@ref) like [`Image`](@ref) or [`Layout`](@ref) Will 
-    be detected automatically
+- `scheme`: ColorSchemes.jl scheme(s), or `Greyscale()`. ObjectScheme() by default.
+    A `Vector/Matrix` for multiple grids, matching the `layout` array. 
+- `renderer`: [`Renderer`](@ref) like [`Image`](@ref) or [`Layout`](@ref) Will be detected 
+    automatically. A `Vector/Matrix` for multiple grids, matching the `layout` array. 
 """
 struct ImageConfig{IB,Min,Max,Bu,TC}
     renderer::IB
@@ -27,11 +28,10 @@ struct ImageConfig{IB,Min,Max,Bu,TC}
 end
 function ImageConfig(init; 
     font=autofont(), text=TextConfig(; font=font), textconfig=text, 
-    scheme=ObjectScheme(), 
     imagegen=nothing, renderer=imagegen,
     minval=nothing, maxval=nothing, kw...
 ) 
-    renderer = renderer isa Nothing ? autorenderer(init, scheme; kw...) : renderer
+    renderer = renderer isa Nothing ? autorenderer(init; kw...) : renderer
     imagebuffer = _allocimage(renderer, init)
     ImageConfig(renderer, minval, maxval, imagebuffer, textconfig)
 end

--- a/src/outputs/render.jl
+++ b/src/outputs/render.jl
@@ -129,7 +129,12 @@ end
 A [`Renderer`](@ref) that checks [`SparseOpt`](@ref) visually.
 Cells that do not run show in gray. Errors show in red, but if they do there's a bug.
 """
-struct SparseOptInspector <: SingleGridRenderer end
+struct SparseOptInspector{A} <: SingleGridRenderer 
+    accessor::A
+end
+SparseOptInspector() = SparseOptInspector(identity)
+
+accessor(p::SparseOptInspector) = p.accessor
 
 function cell_to_pixel(p::SparseOptInspector, mask, minval, maxval, data::AbstractSimData, val, I::Tuple)
     opt(data) isa SparseOpt || error("Can only use SparseOptInspector with SparseOpt grids")
@@ -244,8 +249,11 @@ _get(::Nothing, I) = nothing
 _get(vals, I) = vals[I]
 
 _grid_ids(id::Symbol) = id
+_grid_ids(id::Integer) = id
+_grid_ids(::Nothing) = nothing
+_grid_ids(::Missing) = missing
 _grid_ids(id::Pair{Symbol}) = first(id)
-_grid_ids(id) = throw(ArgumentError("Layout id $id is not a valid grid name. Use a `Symbol` or `Pair{Symbol,<:Any}`"))
+_grid_ids(id) = throw(ArgumentError("Layout id $id is not a valid grid name. Use an `Int`, `Symbol`, `Pair{Symbol,<:Any}` or `nothing`"))
 
 _grid_accessor(id::Pair) = last(id)
 _grid_accessor(id) = nothing

--- a/test/image.jl
+++ b/test/image.jl
@@ -214,8 +214,10 @@ end
 
     output = NoDisplayImageOutput(multiinit; 
         tspan=DateTime(2001):Year(1):DateTime(2002), 
-        renderer=rndr, text=nothing,
-        minval=[0 nothing 0], maxval=[10 nothing 20], store=true
+        renderer=rndr, 
+        text=nothing,
+        minval=[0 nothing 0], maxval=[10 nothing 20], 
+        store=true
     )
     @test minval(output) == [0 nothing 0]
     @test maxval(output) == [10 nothing 20]
@@ -252,21 +254,29 @@ end
             nameposb = 3timepixels + namepixels + 400, timepixels
             renderstring!(refimg, "b", face, namepixels, nameposb...;
                           fcolor=ARGB32(RGB(1.0), 1.0), bcolor=ARGB32(RGB(0.0), 1.0))
-            textconfig = TextConfig(; font=font, timepixels=timepixels, namepixels=namepixels, bcolor=ARGB32(0))
+            textconf = TextConfig(; font=font, timepixels=timepixels, namepixels=namepixels, bcolor=ARGB32(0))
 
             # Build renderer
-            rndr = Layout([:a, nothing, :b], [grey, nothing, leonardo])
             output = NoDisplayImageOutput(textinit; 
-                 tspan=DateTime(2001):Year(1):DateTime(2001), renderer=rndr, text=textconfig,
-                 store=true, minval=[0, nothing, 0], maxval=[1, nothing, 1]
+                 tspan=DateTime(2001):Year(1):DateTime(2001), 
+                 text=textconf,
+                 store=true, 
+                 layout=[:a, nothing, :b],
+                 scheme=[grey, nothing, leonardo],
+                 minval=[0, nothing, 0], 
+                 maxval=[1, nothing, 1]
             )
+
+            output.imageconfig.renderer
+
             simdata = SimData(output, Ruleset())
             img = render!(output, simdata);
             @test img == refimg
         end
     end
     @testset "errors" begin
-        output = NoDisplayImageOutput(multiinit; tspan=1:10, renderer=rndr, 
+        output = NoDisplayImageOutput(multiinit; 
+            tspan=1:10, renderer=rndr, 
             minval=[0, 0, 0], 
             maxval=[10, 20], 
         )

--- a/test/image.jl
+++ b/test/image.jl
@@ -199,7 +199,7 @@ end
              y y y y y w c
              y y y y y c c
              y y y y y y y
-            ]
+    ]
 
 end
 

--- a/test/objectgrids.jl
+++ b/test/objectgrids.jl
@@ -188,7 +188,7 @@ end
         tspan=1:3, 
         store=true,
         layout=[:grid1=>1 :grid1=>x->x[2]],
-        renderers=[Greyscale() Greyscale()],
+        scheme=[Greyscale() Greyscale()],
         minval=[0.0 0.0], maxval=[10.0 10.0],
         text=nothing,
     )


### PR DESCRIPTION
@jamesmaino and @virgile-baudrot these are some new ideas I had to improve specifying the layout, with the complex models Virgile is writing.

Editing the code I could see that you couldn't really visualize a grid of `SVector` in a sane way, even though it makes the most sense for performance and having to specify less rules. So using many grids and heaps of rules was the only option. This is meant to solve that, and make it easier to visualize grids of arbitrary objects.

This test setup is the interesting part of the PR:

```julia
output = GifOutput(init; 
    filename="sa.gif",
    tspan=1:3, 
    store=true,
    layout=[:grid1=>1 :grid1=>x->x[2]],
    renderers=[Greyscale() Greyscale()],
    minval=[0.0 0.0], 
    maxval=[10.0 10.0],
    text=nothing,
)
```

Key points being:
- everything (layout, scheme, renderers, minval, maxval) is specified in the output constructor. 
- You use the `Vector/Matrix` representing the same layout, in the same shape, for all of them. I think this is easier to understand than when `minval/maxval` referred to the grids, not the layout. And it works better when one grid has multiple values, What do you think?
- the layout syntax can inlcude `Pairs`  like `:a=>1` which can give an index into the `SArray` or pass a function to get a `Real` value back from a more complicated object.
- since the last PR these things are called `Renderers` and they `render!` an image from a grid, which seems like the right word now.

Does this make sense and seem more usable?

