### PR TITLE
inherit from StaticArray, generalise grid dimensions

### DIFF
--- a/src/atomic.jl
+++ b/src/atomic.jl
@@ -8,15 +8,15 @@ const atomic_ops = ((:add!, :+), (:sub!, :-), (:min!, :min), (:max!, :max),
 for (f, op) in atomic_ops
     @eval begin
         @propagate_inbounds ($f)(d::AbstractSimData, x, I...) = ($f)(first(d), x, I...)
-        @propagate_inbounds ($f)(d::WritableGridData, x, I...) = ($f)(d, proc(d), x, I...)
-        @propagate_inbounds function ($f)(d::WritableGridData, ::Processor, x, I...)
+        @propagate_inbounds ($f)(d::WritableGridData{<:Any,R}, x, I...) where R = ($f)(d, proc(d), x, I...)
+        @propagate_inbounds function ($f)(d::WritableGridData{<:Any,R}, ::Processor, x, I...) where R
             @boundscheck checkbounds(dest(d), I...)
             @inbounds _setdeststatus!(d, x, I...)
             @inbounds dest(d)[I...] = ($op)(dest(d)[I...], x)
         end
         @propagate_inbounds function ($f)(
-            d::WritableGridData, proc::Union{ThreadedCPU,CPUGPU}, x, I...
-        )
+            d::WritableGridData{<:Any,R}, proc::Union{ThreadedCPU,CPUGPU}, x, I...
+        ) where R
             lock(proc)
             ($f)(d, SingleCPU(), x, I...)
             unlock(proc)

--- a/src/boundaries.jl
+++ b/src/boundaries.jl
@@ -31,11 +31,11 @@ end
 # Reset or wrap boundary where required. This allows us to ignore 
 # bounds checks on neighborhoods and still use a wraparound grid.
 _updateboundary!(grids::Tuple) = map(_updateboundary!, grids)
-function _updateboundary!(g::GridData{Y,X,R}) where {Y,X,R}
+function _updateboundary!(g::GridData{S,R}) where {S<:Tuple{Y,X},R} where {Y,X}
     R < 1 && return g
     return _updateboundary!(g, boundary(g))
 end
-function _updateboundary!(g::GridData{Y,X,R,T}, ::Remove) where {Y,X,R,T}
+function _updateboundary!(g::GridData{S,R}, ::Remove) where {S<:Tuple{Y,X},R} where {Y,X}
     src = parent(source(g))
     # Left
     @inbounds src[1:Y, 1:R] .= Ref(padval(g))
@@ -48,7 +48,7 @@ function _updateboundary!(g::GridData{Y,X,R,T}, ::Remove) where {Y,X,R,T}
     status = sourcestatus(g)
     return g
 end
-function _updateboundary!(g::GridData{Y,X,R}, ::Wrap) where {Y,X,R}
+function _updateboundary!(g::GridData{S,R}, ::Wrap) where {S<:Tuple{Y,X},R} where {Y,X}
     src = parent(source(g))
     nrows, ncols = gridsize(g)
     startpadrow = startpadcol = 1:R

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -50,7 +50,7 @@ _copyto_output!(outgrid, grid::GridData, proc::GPU) = copyto!(outgrid, gridview(
 for (f, op) in atomic_ops
     atomic_f = Symbol(:atomic_, f)
     @eval begin
-        @propagate_inbounds function ($f)(d::WritableGridData{Y,X,R}, ::CuGPU, x, I...) where {Y,X,R}
+        @propagate_inbounds function ($f)(d::WritableGridData{<:Any,R}, ::CuGPU, x, I...) where R
             A = parent(dest(d))
             i = Base._to_linear_index(A, (I .+ R)...)
             (CUDA.$atomic_f)(pointer(A, i), x)

--- a/src/generated.jl
+++ b/src/generated.jl
@@ -100,14 +100,14 @@ end
     expr = Expr(:block)
     keys = map(_unwrap, Tuple(K.parameters))
     for (i, k) in enumerate(keys) 
-        # MUST write to dest(grid) here, not grid K
+        # MUST write to source(grid) - CellRule doesn't switch grids
         push!(expr.args, :(@inbounds source(data[$(QuoteNode(k))])[I...] = vals[$i]))
     end
     push!(expr.args, :(nothing))
     return expr
 end
 @inline function _writecell!(data, ::Val{<:CellRule}, wkeys::Val{K}, val, I...) where K
-    # MUST write to dest(grid) here, not grid K
+    # MUST write to source(grid) - CellRule doesn't switch grids
     @inbounds source(data[K])[I...] = val
     return nothing
 end

--- a/src/outputs/gif.jl
+++ b/src/outputs/gif.jl
@@ -35,7 +35,6 @@ function savegif(filename::String, o::ImageOutput, ruleset=Ruleset(); fps=fps(o)
         Array(render!(o, simdata, o[f]))
     end
     array = cat(images..., dims=3)
-    @show size(array)
     FileIO.save(filename, array; fps=fps, kw...)
     array
 end

--- a/src/outputs/render.jl
+++ b/src/outputs/render.jl
@@ -48,10 +48,10 @@ function render!(
 end
 function render!(
     imagebuffer, ig::SingleGridRenderer, o::ImageOutput, 
-    data::AbstractSimData{Y,X}, grid::AbstractArray;
+    data::AbstractSimData{S}, grid::AbstractArray;
     name=nothing, time=currenttime(data), accessor=nothing,
     minval=minval(o), maxval=maxval(o),
-) where {Y,X}
+) where S<:Tuple{Y,X} where {Y,X}
     for j in 1:X, i in 1:Y
         @inbounds val = grid[i, j]
         val = if accessor isa Nothing

--- a/test/simulationdata.jl
+++ b/test/simulationdata.jl
@@ -17,6 +17,7 @@ tspan_ = DateTime(2001):Day(1):DateTime(2001, 2)
 
     ext = Extent(; init=initab, tspan=tspan_)
     simdata = SimData(ext, rs)
+
     @test simdata isa SimData
     @test init(simdata) == initab
     @test mask(simdata) === nothing
@@ -43,8 +44,13 @@ tspan_ = DateTime(2001):Day(1):DateTime(2001, 2)
          0 0 0 0 0]
 
     wgrida = WritableGridData(grida)
-    @test parent(grida) == parent(source(grida)) == parent(source(wgrida))
-    @test parent(wgrida) === parent(dest(grida)) === parent(dest(wgrida))
+    @test parent(source(grida)) === parent(source(wgrida))
+    @test parent(dest(grida)) === parent(dest(wgrida))
+
+    @test parent(grida) == parent(wgrida) ==
+        [0 1 1 
+         0 1 1]
+    
 
     @test sourcestatus(grida) == deststatus(grida) == 
         [0 1 0 0


### PR DESCRIPTION
This fixes broadcasting over grids - which is now faster than regular broadcast as we have size in formation. It also generalises grid dimensionality as part of inheriting from `StaticArray`. This makes `GridData` essentially a `SizedArray`.