### PR TITLE
use all args in short form methods

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -382,8 +382,8 @@ end
 Cell{R,W}(; kw...) where {R,W} = _nofunctionerror(Cell)
 
 @inline function applyrule(data, rule::Cell, read, I)
-    let rule=rule, read=read
-        rule.f(read)
+    let data=data, rule=rule, read=read, I=I
+        rule.f(data, read, I)
     end
 end
 
@@ -428,8 +428,8 @@ Neighbors{R,W}(f; neighborhood=Moore(1)) where {R,W} =
     Neighbors{R,W}(f, neighborhood)
 
 @inline function applyrule(data, rule::Neighbors, read, I)
-    let rule=rule, hood=neighborhood(rule), read=read
-        rule.f(hood, read)
+    let rule=rule, hood=neighborhood(rule), read=read, I=I
+        rule.f(data, hood, read, I)
     end
 end
 

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -5,19 +5,19 @@ using DynamicGrids: SimData, radius, rules, _readkeys, _writekeys,
 
 @testset "CellRule chain" begin
 
-    rule1 = Cell{:a,:b}() do a
+    rule1 = Cell{:a,:b}() do data, a, I
         2a
     end
 
-    rule2 = Cell{Tuple{:b,:d},:c}() do (b, d)
+    rule2 = Cell{Tuple{:b,:d},:c}() do data, (b, d), I
         b + d
     end
 
-    rule3 = Cell{Tuple{:a,:c,:d},Tuple{:d,:e}}() do (a, c, d)
+    rule3 = Cell{Tuple{:a,:c,:d},Tuple{:d,:e}}() do data, (a, c, d), I
         a + c + d, 3a
     end
 
-    rule4 = Cell{Tuple{:a,:b,:c,:d},Tuple{:a,:b,:c,:d}}() do (a, b, c, d)
+    rule4 = Cell{Tuple{:a,:b,:c,:d},Tuple{:a,:b,:c,:d}}() do data, (a, b, c, d), I
         2a, 2b, 2c, 2d
     end
 
@@ -96,11 +96,11 @@ end
 
     buf = reshape(1:9, 3, 3)
     hood = Moore{1}(buf)
-    hoodrule = Neighbors{:a,:a}(hood) do neighborhodhood, cell
+    hoodrule = Neighbors{:a,:a}(hood) do data, neighborhodhood, cell, I
         sum(neighborhodhood)
     end
 
-    rule = Cell{Tuple{:a,:c},:b}() do (b, c)
+    rule = Cell{Tuple{:a,:c},:b}() do data, (b, c), I
         b + c 
     end
 

--- a/test/condition.jl
+++ b/test/condition.jl
@@ -3,7 +3,7 @@ using DynamicGrids: ruletype
 
 @testset "RunIf" begin
     @testset "CellRule" begin
-        rule = Cell{:a,:a}() do a
+        rule = Cell{:a,:a}() do data, a, I
             10a
         end
         condition = RunIf(rule) do data, state, index
@@ -22,7 +22,7 @@ using DynamicGrids: ruletype
         @test output[3][:a] == [10 20 3; 0 4 -100]
     end
     @testset "NeighborhoodRule" begin
-        neighborsrule = Neighbors{:a,:a}(Moore{1}()) do hood, a
+        neighborsrule = Neighbors{:a,:a}(Moore{1}()) do data, hood, a, I
             sum(hood)
         end
         condition = RunIf(neighborsrule) do data, state, index
@@ -53,9 +53,9 @@ using DynamicGrids: ruletype
 end
 
 @testset "RunAt" begin
-    rule = Cell{:a,:a}(a -> a + 1)
-    timedrule1 = Cell{:a,:a}(a -> 4a)
-    timedrule2 = Cell{:a,:a}(a -> a ÷ 2)
+    rule = Cell{:a,:a}((d, a, I) -> a + 1)
+    timedrule1 = Cell{:a,:a}((d, a, I) -> 4a)
+    timedrule2 = Cell{:a,:a}((d, a, I) -> a ÷ 2)
     runatrule = RunAt(timedrule1, timedrule2; times=DateTime(2001, 3):Month(2):DateTime(2001, 5))
 
     init = (a=[1 2 3; 0 4 -5],)

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -405,7 +405,7 @@ end
             data[p...] = 2
         end
     end
-    clearcell = Cell() do val
+    clearcell = Cell() do data, val, I
         zero(val)
     end
     output = ArrayOutput(ones(10, 11); tspan=1:3)

--- a/test/objectgrids.jl
+++ b/test/objectgrids.jl
@@ -2,7 +2,7 @@ using DynamicGrids, StaticArrays, Test, FileIO, Colors, FixedPointNumbers
 using DynamicGrids: SimData, NoDisplayImageOutput
 
 @testset "CellRule that multiples a StaticArray" begin
-    rule = Cell{:grid1}() do state
+    rule = Cell{:grid1}() do data, state, I
          2state
     end
     init = (grid1 = fill(SA[1.0, 2.0], 5, 5),)
@@ -25,8 +25,8 @@ using DynamicGrids: SimData, NoDisplayImageOutput
 end
 
 @testset "Neighborhood Rule that sums a Neighborhood of StaticArrays" begin
-    rule = Neighbors{Tuple{:grid1,:grid2},:grid1}(Moore(1)) do neighborhood, (state1, state2)
-        sum(neighborhood) .+ state2
+    rule = Neighbors{Tuple{:grid1,:grid2},:grid1}(Moore(1)) do data, hood, (s1, s2), I
+        sum(hood) .+ s2
     end
     init = (
         grid1 = fill(SA[1.0, 2.0], 5, 5),
@@ -81,7 +81,7 @@ DynamicGrids.to_rgb(scheme, obj::TestStruct) = get(scheme, obj.a)
 
 
 @testset "CellRule that multiples a struct" begin
-    rule = Cell{:grid1,:grid1}() do state
+    rule = Cell{:grid1,:grid1}() do data, state, I
          2state
     end
     init = (grid1 = fill(TS(1.0, 2.0), 5, 5),)
@@ -104,8 +104,8 @@ DynamicGrids.to_rgb(scheme, obj::TestStruct) = get(scheme, obj.a)
 end
 
 @testset "Neighborhood Rule that sums a Neighborhood of stucts" begin
-    rule = Neighbors{Tuple{:grid1,:grid2},:grid1}(Moore(1)) do neighborhood, (state1, state2)
-        sum(neighborhood) * state2
+    rule = Neighbors{Tuple{:grid1,:grid2},:grid1}(Moore(1)) do data, hood, (s1, s2), I
+        sum(hood) * s2
     end
     init = (
         grid1 = fill(TS(1.0, 2.0), 5, 5),
@@ -176,7 +176,7 @@ end
 end
 
 @testset "static arrays grid can generate an image" begin
-    rule = Cell{:grid1}() do state
+    rule = Cell{:grid1}() do data, state, I
          2state
     end
     init = (grid1 = fill(SA[1.0, 2.0], 5, 5),)

--- a/test/parametersources.jl
+++ b/test/parametersources.jl
@@ -105,12 +105,12 @@ end
     end
 
     @testset "CopyTo from Grid" begin
-        ruleset = Ruleset(Cell{:s,:s}(x -> x + 1), CopyTo{:d}(from=Grid(:s)))
+        ruleset = Ruleset(Cell{:s,:s}((d, x, I) -> x + 1), CopyTo{:d}(from=Grid(:s)))
         output = ArrayOutput((s=[1 3], d=[0 0],); tspan=1d:1d:3d)
         sim!(output, ruleset)
         @test output == [(s=[1 3], d=[0 0]), (s=[2 4], d=[2 4]), (s=[3 5], d=[3 5])]
 
-        ruleset = Ruleset(Cell{:s,:s}(x -> x + 1), CopyTo{Tuple{:d1,:d2}}(from=Grid{:s}()))
+        ruleset = Ruleset(Cell{:s,:s}((d, x, I) -> x + 1), CopyTo{Tuple{:d1,:d2}}(from=Grid{:s}()))
         output = ArrayOutput((s=[1 3], d1=[0 0], d2=[-1 -1],); tspan=1d:1d:3d)
         sim!(output, ruleset)
         @test output == [(s=[1 3], d1=[0 0], d2=[-1 -1]), 
@@ -119,7 +119,7 @@ end
     end
 
     @testset "CopyTo from Delay" begin
-        ruleset = Ruleset(Cell{:s,:s}(x -> x + 1), CopyTo{:d}(from=Delay{:s}(1d)))
+        ruleset = Ruleset(Cell{:s,:s}((d, x, I) -> x + 1), CopyTo{:d}(from=Delay{:s}(1d)))
         @test DynamicGrids.hasdelay(rules(ruleset)) == true
         output = ArrayOutput((s=[1 3], d=[0 0],); tspan=1d:1d:4d)
         sim!(output, ruleset)
@@ -130,7 +130,7 @@ end
             (s=[4 6], d=[3 5])
         ]
 
-        ruleset = Ruleset(Cell{:s,:s}(x -> x + 1), CopyTo{:d}(from=Delay{:s}(Month(2))))
+        ruleset = Ruleset(Cell{:s,:s}((d, x, I) -> x + 1), CopyTo{:d}(from=Delay{:s}(Month(2))))
         @test DynamicGrids.hasdelay(rules(ruleset)) == true
         output = ArrayOutput((s=[1 3], d=[0 0]); tspan=Date(2001):Month(1):Date(2001, 6))
         sim!(output, ruleset)
@@ -146,7 +146,7 @@ end
     end
 
     @testset "CopyTo from Lag" begin
-        ruleset = Ruleset(Cell{:s,:s}(x -> x + 1), CopyTo{:d}(from=Lag{:s}(1)))
+        ruleset = Ruleset(Cell{:s,:s}((d, x, I) -> x + 1), CopyTo{:d}(from=Lag{:s}(1)))
         @test DynamicGrids.hasdelay(rules(ruleset)) == true
         output = ArrayOutput((s=[1 3], d=[0 0],); tspan=1d:1d:4d)
         sim!(output, ruleset)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -74,17 +74,17 @@ end
 end
 
 @testset "Cell" begin
-    rule = Cell(x -> 2x)
+    rule = Cell((d, x, I) -> 2x)
     @test applyrule(nothing, rule, 1, (0, 0)) == 2
 end
 
 @testset "Neighbors" begin
     buf = [1 0 0; 0 0 1; 0 0 1]
-    rule = Neighbors(VonNeumann(1, buf)) do hood, state
+    rule = Neighbors(VonNeumann(1, buf)) do data, hood, state, I
         sum(hood)
     end
     @test applyrule(nothing, rule, 0, (3, 3)) == 1
-    rule = Neighbors(Moore{1}(buf)) do hood, state
+    rule = Neighbors(Moore{1}(buf)) do data, hood, state, I
         sum(hood)
     end
     @test applyrule(nothing, rule, 0, (3, 3)) == 3
@@ -364,6 +364,7 @@ applyrule(data, rule::PrecalcRule, state, index) = rule.precalc[]
             ruleset = Ruleset(rule; proc=proc, opt=opt)
             output = ArrayOutput(init; tspan=1:3)
             sim!(output, ruleset)
+            # Copy for GPU
             @test output[2] == out2
             @test output[3] == out3
         end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -40,7 +40,7 @@ end
 @testset "isinferred" begin
     @testset "unstable conditional" begin
         rule = let threshold = 20
-            Cell() do x
+            Cell() do data, x, I
                 x > 1 ? 2 : 0.0
             end
         end
@@ -49,7 +49,7 @@ end
     end
 
     @testset "return type" begin
-        rule = Neighbors{:a,:a}(Moore{1}(zeros(Bool, 3, 3))) do hood, x
+        rule = Neighbors{:a,:a}(Moore{1}(zeros(Bool, 3, 3))) do data, hood, x, I
             round(Int, x + sum(hood))
         end
         output = ArrayOutput((a=rand(Int, 10, 10),); tspan=1:10)


### PR DESCRIPTION
This PR changes the syntax for for form Rule definitions. so

```julia
Cell{:a}() do val
    ...
end
```
Is now
```julia
Cell{:a}() do data, val, I
    ...
end
```

It makes some cases a little more verbose, but means you can do anything you can do with a struct base model (now that we can use `Param`s with them too), like e.g. use Aux/Lag data.

I have found I can iterate more easily on a complex model because you don't have to modify struct fields to add/remove parameters - the anonymous functions are doing that for you behind the scenes. See the [Green Peach Aphid](https://github.com/cesaraustralia/GreenPeachAphidMigration/blob/master/src/original.jl) model for how tight this can make a really complicated model. It's no more code than the R for a single location model, and it's really easy to change.

@jamesmaino and @virgile-baudrot I'm looking for some fedback because this will be a breaking change.