### PR TITLE
More auto rendering

### DIFF
--- a/src/outputs/image.jl
+++ b/src/outputs/image.jl
@@ -29,7 +29,7 @@ end
 function ImageConfig(init; 
     font=autofont(), text=TextConfig(; font=font), textconfig=text, 
     imagegen=nothing, renderer=imagegen,
-    minval=nothing, maxval=nothing, kw...
+    minval=0, maxval=1, kw...
 ) 
     renderer = renderer isa Nothing ? autorenderer(init; kw...) : renderer
     imagebuffer = _allocimage(renderer, init)

--- a/test/image.jl
+++ b/test/image.jl
@@ -96,7 +96,7 @@ end
         @test _autokeys((a=[[0,0]], b=[1], c=[[3,4]])) == (:a=>1, :a=>2, :b, :c=>1, :c=>2)
         @test _autolayout([0]) == reshape(Any[1], 1, 1)
         @test _autolayout((a=[0], b=[0], c=[0])) == Any[:a :b :c]
-        @testset "Empty layout cells are fileld with nothing" begin
+        @testset "Empty layout cells are filled with nothing" begin
             @test _autolayout((a=[[0,0]], b=[1], c=[[3,4]])) == Any[:a=>1 :b :c=>2; :a=>2 :c=>1 nothing]
         end
     end

--- a/test/objectgrids.jl
+++ b/test/objectgrids.jl
@@ -71,6 +71,8 @@ Base.:*(x::Number, ts::TestStruct) = TestStruct(x * ts.a, x * ts.b)
 Base.:/(ts::TestStruct, x::Number) = TestStruct(ts.a / x, ts.b / x) 
 Base.:+(ts1::TestStruct, ts2::TestStruct) = TestStruct(ts1.a + ts2.a, ts1.b + ts2.b)
 Base.:-(ts1::TestStruct, ts2::TestStruct) = TestStruct(ts1.a - ts2.a, ts1.b - ts2.b)
+Base.:+(ts::TestStruct, x::Number) = TestStruct(ts.a + x, ts.b + x)
+Base.:-(ts::TestStruct, x::Number) = TestStruct(ts.a - x, ts.b - x)
 
 Base.isless(a::TestStruct, b::TestStruct) = isless(a.a, b.a)
 Base.zero(::Type{<:TestStruct{T1,T2}}) where {T1,T2} = TestStruct(zero(T1), zero(T2))


### PR DESCRIPTION
In an attempt to impress @virgile-baudrot with the virtues of  our native DynamicGrids.jl `ImageOutput`, this PR automates more things so the interface will just work no matter how complicated your grids may be.

- `minval/maxval` can just be single numbers for all grids, and default to 0, 1 to catch RGB conversion errors (they always should have)
- renderers are not only guessed from grids, but from their content! In `_autokeys` we guess that any `AbstractArray` grid cell value should have one image tile for each value. So grids of `SArray` or `FieldVector` will also have automatic interfaces that just work with no config.

@jamesmaino this was also prompted by that crop model conversion, while we are talking about things being too complex...

If you want to review, that would be nice.

Also @virgile-baudrot if you ever found writing simulation gifs was slow, this was the reason:
https://github.com/cesaraustralia/DynamicGrids.jl/pull/166

They are fast now :)