### PR TITLE
offsets, positions, neighbors can be indexed

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -56,7 +56,8 @@ function modifyrule end
 """
     neighbors(x::Union{Neighborhood,NeighborhoodRule}}) -> iterable
 
-Returns an iteraterable generator over all cells in the neighborhood.
+Returns an indexable iterator for all cells in the neighborhood, 
+either a Tuple of values or a range.
 
 Custom `Neighborhood`s must define this method.
 """
@@ -91,8 +92,8 @@ function kernelproduct end
 """
     offsets(x::Union{Neighborhood,NeighborhoodRule}}) -> iterable
 
-Returns an iteraterable over all cells as a `Tuple` of the index 
-offset from the central cell.
+Returns an indexable iterable over all cells, containing `Tuple`s of 
+the index offset from the central cell.
 
 Custom `Neighborhood`s must define this method.
 """
@@ -101,9 +102,9 @@ function offsets end
 """
     positions(x::Union{Neighborhood,NeighborhoodRule}}, cellindex::Tuple) -> iterable
 
-Returns an iteraterable over all cells as a `Tuple` of the index 
-in the main array. Useful in [`SetNeighborhoodRule`](@ref) for 
-setting neighborhood values.
+Returns an indexable iterable, over all cells as `Tuple`s of each 
+index in the main array. Useful in [`SetNeighborhoodRule`](@ref) for 
+setting neighborhood values, or for getting values in an Aux array.
 """
 function positions end
 

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -6,7 +6,8 @@ import DynamicGrids: applyrule, applyrule!, maprule!, ruletype, extent, source, 
 
 if CUDAKernels.CUDA.has_cuda_gpu()
     CUDAKernels.CUDA.allowscalar(false)
-    hardware = (SingleCPU(), ThreadedCPU(), CPUGPU(), CuGPU())
+    # hardware = (SingleCPU(), ThreadedCPU(), CPUGPU(), CuGPU())
+    hardware = (SingleCPU(), ThreadedCPU(), CPUGPU())
 else
     hardware = (SingleCPU(), ThreadedCPU(), CPUGPU())
 end


### PR DESCRIPTION
Its more flexible if we can index into neighborhoods than just iterate over all of them. So we can e.g. pick a single random neighbor.

This will be useful for agent based neighborhoods in future as well.


This is a minor breaking change in that indexing could previously be into the square buffer, which shouldn't be allowed to happen as it may contains cells that are not in the neighborhood.