### PR TITLE
add warning labels to experimetal features

### DIFF
--- a/src/DynamicGrids.jl
+++ b/src/DynamicGrids.jl
@@ -82,7 +82,7 @@ const DEFAULT_KEY = :_default_
 
 const EXPERIMENTAL = """
         WARNING: This feature is experimental. It may change in future versions, 
-        and may not be 100% reliable in all cases.  Please file github issues if problems occur.
+        and may not be 100% reliable in all cases. Please file github issues if problems occur.
         """
 
 

--- a/src/DynamicGrids.jl
+++ b/src/DynamicGrids.jl
@@ -80,6 +80,11 @@ export CharStyle, Block, Braile
 
 const DEFAULT_KEY = :_default_
 
+const EXPERIMENTAL = """
+        WARNING: This feature is experimental. It may change in future versions, 
+        and may not be 100% reliable in all cases.  Please file github issues if problems occur.
+        """
+
 
 function __init__()
     global terminal

--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -18,6 +18,7 @@ An output that stores the result of some function `f` of the grid/s
 - `mask`: `BitArray` for defining cells that will/will not be run.
 - `padval`: padding value for grids with neighborhood rules. The default is `zero(eltype(init))`.
 
+$EXPERIMENTAL
 """
 mutable struct TransformedOutput{T,A<:AbstractVector{T},E,F,B} <: Output{T,A} 
     frames::A

--- a/src/parametersources.jl
+++ b/src/parametersources.jl
@@ -151,6 +151,8 @@ _unwrap(::Type{<:Grid{X}}) where X = X
 
 Abstract supertype for [`ParameterSource`](@ref)s that use data from a grid
 with a time delay.
+
+$EXPERIMENTAL
 """
 abstract type AbstractDelay{K} <: ParameterSource end
 
@@ -197,6 +199,8 @@ SomeRule(;
     otherparam=1.075
 )
 `` `
+
+$EXPERIMENTAL
 """
 struct Delay{K,S} <: AbstractDelay{K}
     steps::S
@@ -244,6 +248,8 @@ SomeRule(;
     otherparam=1.075
 )
 `` `
+
+$EXPERIMENTAL
 """
 struct Lag{K} <: AbstractDelay{K}
     nframes::Int
@@ -271,6 +277,8 @@ a rule, using `get`. It should only be used within rule code, not as a parameter
 # Argument
 
 - `frame::Int`: the exact frame number to use.
+
+$EXPERIMENTAL
 """
 struct Frame{K} <: AbstractDelay{K}
     frame::Int


### PR DESCRIPTION
This adds a warning label to experimental features. We should do this with new things that are not fully worked through so that it is clear that they may change.