### PR TITLE
Allow ParameterSource indexing with Tuple or CartesianIndex

### DIFF
--- a/src/copyto.jl
+++ b/src/copyto.jl
@@ -18,6 +18,6 @@ CopyTo{W}(; from) where W = CopyTo{W,typeof(from)}(from)
 
 ConstructionBase.constructorof(::Type{<:CopyTo{W}}) where W = CopyTo{W}
 
-DynamicGrids.applyrule(data, rule::CopyTo, state, I) = get(data, rule.from, I...)
+DynamicGrids.applyrule(data, rule::CopyTo, state, I) = get(data, rule.from, I)
 DynamicGrids.applyrule(data, rule::CopyTo{W}, state, I) where W <: Tuple =
-    ntuple(i -> get(data, rule.from, I...), length(_asiterable(W)))
+    ntuple(i -> get(data, rule.from, I), length(_asiterable(W)))

--- a/src/parametersources.jl
+++ b/src/parametersources.jl
@@ -64,14 +64,7 @@ _unwrap(::Type{<:Aux{X}}) where X = X
 # If there is no time dimension we return the same data for every timestep
 @propagate_inbounds _getaux(data::AbstractSimData, key::Union{Aux,Symbol}, I::Tuple) = _getaux(aux(data, key), data, key, I)
 @propagate_inbounds _getaux(A::AbstractMatrix, data::AbstractSimData, key::Union{Aux,Symbol}, I::Tuple) = A[I...]
-# function _getaux(A::AbstractDimArray{<:Any,2}, data::AbstractSimData, key::Union{Aux,Symbol}, y, x)
-    # X = DD.basetypeof(dims(A, XDim))
-    # Y = DD.basetypeof(dims(A, YDim))
-    # A[y, x]
-# end
 function _getaux(A::AbstractDimArray{<:Any,3}, data::AbstractSimData, key::Union{Aux,Symbol}, I::Tuple)
-    # X = DD.basetypeof(dims(A, XDim))
-    # Y = DD.basetypeof(dims(A, YDim))
     A[I..., auxframe(data, key)]
 end
 
@@ -312,7 +305,6 @@ end
 _getdelays(rules::Tuple) = Flatten.flatten(rules, AbstractDelay, DELAY_IGNORE)
 _setdelays(rules::Tuple, delays::Tuple) = 
     Flatten.reconstruct(rules, delays, AbstractDelay, DELAY_IGNORE)
-
 
 _notstorederror() = 
     throw(ArgumentError("Output does not store frames, which is needed for a Delay. Use ArrayOutput or any GraphicOutput with `store=true` keyword"))

--- a/test/parametersources.jl
+++ b/test/parametersources.jl
@@ -54,16 +54,16 @@ const DG = DynamicGrids
             data = SimData(Extent(init=init, aux=(seq=seq,), tspan=Date(2001):Day(1):Date(2001, 3)), Ruleset())
             data1 = DG._updatetime(data, 1)
             @test data1.auxframe == (seq = 1,)
-            @test get(data1, Aux(:seq), 1, 1) == 0.1
+            @test get(data1, Aux(:seq), (1, 1)) == 0.1
             data2 = DG._updatetime(data, 5)
             @test data2.auxframe == (seq = 2,)
             @test get(data2, Aux(:seq), 1, 1) == 1.1
             data3 = DG._updatetime(data, 10)
             @test data3.auxframe == (seq = 3,)
-            @test get(data3, Aux(:seq), 1, 1) == 2.1
+            @test get(data3, Aux(:seq), (1, 1)) == 2.1
             data4 = DG._updatetime(data, 15)
             @test data4.auxframe == (seq = 1,)
-            @test get(data4, Aux(:seq), 1, 1) == 0.1
+            @test get(data4, Aux(:seq), CartesianIndex(1, 1)) == 0.1
         end
 
         @testset "errors" begin


### PR DESCRIPTION
This PR allows indexing Aux, Grid, Delay etc using a `Tuple` or `CartesianIndex`. 

Basically so we don't have to splat.