### PR TITLE
generalise time sync to arbitrary dims

### DIFF
--- a/src/settings.jl
+++ b/src/settings.jl
@@ -17,9 +17,6 @@ Base.@kwdef struct SimSettings{B,P,O,C,T} <: AbstractSimSettings
     cellsize::C = 1
     timestep::T = nothing
 end
-function SimSettings(boundary::B, proc::P, opt::O, cellsize::C, timestep::T) where {B,P,O,C,T}
-    SimSettings{B,P,O,C,T}(boundary, proc, opt, cellsize, timestep)
-end
 
 boundary(s::AbstractSimSettings) = s.boundary
 proc(s::AbstractSimSettings) = s.proc

--- a/src/sparseopt.jl
+++ b/src/sparseopt.jl
@@ -35,7 +35,6 @@ SparseOpt() = SparseOpt(==(0))
 sourcestatus(d::GridData) = optdata(d).sourcestatus
 deststatus(d::GridData) = optdata(d).deststatus
 
-
 # Run kernels with SparseOpt, block by block:
 function optmap(
     f, simdata::AbstractSimData{S}, proc, ::SparseOpt, ruletype::Val{<:Rule}, rkeys
@@ -170,9 +169,6 @@ end
 
 @inline _cellstatus(opt::SparseOpt, wkeys::Tuple, writeval) = _isactive(writeval[1], opt)
 @inline _cellstatus(opt::SparseOpt, wkeys, writeval) = _isactive(writeval, opt)
-
-sourcestatus(d::GridData) = optdata(d).sourcestatus
-deststatus(d::GridData) = optdata(d).deststatus
 
 # SparseOpt methods
 

--- a/test/parametersources.jl
+++ b/test/parametersources.jl
@@ -38,50 +38,96 @@ const DG = DynamicGrids
         end
 
         @testset "boundscheck_aux" begin
-            seq = DimArray(a, (X(1:2), Y(1:2), Ti(15d:5d:25d)))
-            bigseq = DimArray(zeros(5, 2, 3), (X(1:5), Y(1:2), Ti(15d:5d:25d)))
-            init = zero(seq[Ti(1)])
-            sd = SimData(Extent(init=init, aux=(seq=seq, bigseq=bigseq), tspan=1d:1d:100d), Ruleset())
-            @test DynamicGrids.boundscheck_aux(sd, Aux{:seq}()) == true
-            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd, Aux{:bigseq}())
-            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd, Aux{:missingseq}())
+            seq1 = zeros(Ti(15d:5d:25d))
+            seq3 = zeros((X(1:2), Y(1:2), Ti(15d:5d:25d)))
+            auxarray1 = zeros(X(3))
+            auxarray2 = zeros(dims(seq3, (X, Y)))
+            bigseq = zeros((X(1:5), Y(1:2), Ti(15d:5d:25d)))
+            aux1 = (seq=seq1, a1=auxarray1, a2=auxarray2)
+            sd1 = SimData(Extent(init=zeros(3), aux=aux1, tspan=1d:1d:100d), Ruleset())
+            aux2 = (seq=seq3, bigseq=bigseq, a1=auxarray1, a2=auxarray2)
+            sd2 = SimData(Extent(init=zero(seq3[Ti(1)]), aux=aux2, tspan=1d:1d:100d), Ruleset())
+            @test DynamicGrids.boundscheck_aux(sd1, Aux{:seq}()) == true
+            @test DynamicGrids.boundscheck_aux(sd1, Aux{:a1}()) == true
+            @test DynamicGrids.boundscheck_aux(sd2, Aux{:seq}()) == true
+            @test DynamicGrids.boundscheck_aux(sd2, Aux{:a2}()) == true
+            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd1, Aux{:a2}())
+            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd2, Aux{:a1}())
+            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd2, Aux{:bigseq}())
+            @test_throws ErrorException DynamicGrids.boundscheck_aux(sd2, Aux{:missingseq}())
         end
 
         @testset "correct values are returned by get" begin
-            dimz = X(1:2), Y(1:2), Ti(Date(2001, 1, 15):Day(5):Date(2001, 1, 25))
-            seq = DimArray(a, dimz)
-            init = zero(seq[Ti(1)])
-            data = SimData(Extent(init=init, aux=(seq=seq,), tspan=Date(2001):Day(1):Date(2001, 3)), Ruleset())
-            data1 = DG._updatetime(data, 1)
-            @test data1.auxframe == (seq = 1,)
-            @test get(data1, Aux(:seq), (1, 1)) == 0.1
-            data2 = DG._updatetime(data, 5)
-            @test data2.auxframe == (seq = 2,)
-            @test get(data2, Aux(:seq), 1, 1) == 1.1
-            data3 = DG._updatetime(data, 10)
-            @test data3.auxframe == (seq = 3,)
-            @test get(data3, Aux(:seq), (1, 1)) == 2.1
-            data4 = DG._updatetime(data, 15)
-            @test data4.auxframe == (seq = 1,)
-            @test get(data4, Aux(:seq), CartesianIndex(1, 1)) == 0.1
+            x, y, ti = X(1:2), Y(1:2), Ti(Date(2001, 1, 15):Day(5):Date(2001, 1, 25))
+            @testset "1d" begin
+                seq1 = DimArray(a[2, 2, :], ti)
+                seq3 = DimArray(a[:, 1, :], (x, ti))
+                init = zero(seq3[Ti(1)])
+                tspan = Date(2001):Day(1):Date(2001, 3)
+                data = SimData(Extent(init=init, aux=(; seq1, seq3), tspan=tspan), Ruleset())
+                data1 = DG._updatetime(data, 1)
+                @test data1.auxframe == (seq1 = 1, seq3 = 1,)
+                # I is ignored for 1d with Ti dim
+                @test get(data1, Aux(:seq1), (-10,)) == 0.4
+                @test get(data1, Aux(:seq3), (1)) == 0.1
+                dims(seq1, Ti) === dims(seq3, Ti)
+                data2 = DG._updatetime(data, 5);
+                @test data2.auxframe == (seq1 = 2, seq3 = 2,)
+                @test get(data2, Aux(:seq1), 11) == 1.4
+                @test get(data2, Aux(:seq3), 1) == 1.1
+                data3 = DG._updatetime(data, 10)
+                @test data3.auxframe == (seq1 = 3, seq3 = 3,)
+                @test get(data3, Aux(:seq1), (1,)) == 2.4
+                @test get(data3, Aux(:seq3), (1,)) == 2.1
+                data4 = DG._updatetime(data, 15)
+                @test data4.auxframe == (seq1 = 1, seq3 = 1,)
+                @test get(data4, Aux(:seq1), CartesianIndex(1,)) == 0.4
+                @test get(data4, Aux(:seq3), CartesianIndex(1,)) == 0.1
+            end
+            @testset "2d" begin
+                seq1 = DimArray(a[2, 2, :], ti)
+                seq3 = DimArray(a, (x, y, ti))
+                init = zero(seq3[Ti(1)])
+                tspan = Date(2001):Day(1):Date(2001, 3)
+                data = SimData(Extent(init=init, aux=(; seq1, seq3), tspan=tspan), Ruleset())
+                data1 = DG._updatetime(data, 1)
+                @test data1.auxframe == (seq1 = 1, seq3 = 1,)
+                # I is ignored for 1d with Ti dim
+                @test get(data1, Aux(:seq1), (-10, 17)) == 0.4
+                @test get(data1, Aux(:seq3), (1, 1)) == 0.1
+                dims(seq1, Ti) === dims(seq3, Ti)
+                data2 = DG._updatetime(data, 5);
+                @test data2.auxframe == (seq1 = 2, seq3 = 2,)
+                @test get(data2, Aux(:seq1), 11, 1) == 1.4
+                @test get(data2, Aux(:seq3), 1, 1) == 1.1
+                data3 = DG._updatetime(data, 10)
+                @test data3.auxframe == (seq1 = 3, seq3 = 3,)
+                @test get(data3, Aux(:seq1), (1, 10)) == 2.4
+                @test get(data3, Aux(:seq3), (1, 1)) == 2.1
+                data4 = DG._updatetime(data, 15)
+                @test data4.auxframe == (seq1 = 1, seq3 = 1,)
+                @test get(data4, Aux(:seq1), CartesianIndex(1, 1)) == 0.4
+                @test get(data4, Aux(:seq3), CartesianIndex(1, 1)) == 0.1
+            end
         end
 
         @testset "errors" begin
             output = ArrayOutput(zeros(3, 3); tspan=1:3)
             @test_throws ArgumentError  DynamicGrids.aux(output, Aux{:somekey}())
         end
+
     end
 end
 
 # Use copyto to test all parametersources, as well as testing CopyTo itself
 @testset "CopyTo" begin
+    init = [0 0]
+
     @testset "Copy construction" begin
         rule = CopyTo(7)
         rule2 = @set rule.from = Aux{:a}()
         @test rule2.from == Aux{:a}()
     end
-
-    init = [0 0]
 
     @testset "CopyTo from value" begin
         ruleset = Ruleset(CopyTo(7))


### PR DESCRIPTION
this also allows `get(data, Aux{:x}, I)` to work with a vector - ignoring the index position `I`.