### PR TITLE
allow FTFont in TextConfig(font=...)

### DIFF
--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -8,7 +8,7 @@ Text configuration for printing timestep and grid name on the image.
 
 # Arguments / Keywords
 
-- `font`: `String` font name.
+- `font`: `FreeTypeAbstraction.FTFont` (direct), or `String` (font name to look for).
 - `namepixels` and `timepixels`: the pixel size of the font.
 - `timepos` and `namepos`: tuples that set the label positions, in `Int` pixels.
 - `fcolor` and `bcolor`: the foreground and background colors, as `ARGB32`.
@@ -28,7 +28,9 @@ function TextConfig(;
     timepos=(2timepixels, timepixels),
     fcolor=ARGB32(1.0), bcolor=ZEROCOL,
 )
-    if font isa AbstractString
+    if font isa FreeTypeAbstraction.FTFont
+	    face = font
+    elseif font isa AbstractString
         face = FreeTypeAbstraction.findfont(font)
         face isa Nothing && _fontnotfounderror(font)
     else


### PR DESCRIPTION
With this PR, `TextConfig` accepts also an `FTFont`, bypassing the `findfont` call.
```julia
julia> @time gif_output = GifOutput(init;
                  filename="forestfire.gif", tspan=1:200, fps=25,
                  minval=DEAD, maxval=BURNING,
                  scheme=ColorSchemes.rainbow,
                  zerocolor=RGB24(0.0),
                  font="Cantarell"
)
  2.943864 seconds (313.00 k allocations: 155.443 MiB)

julia> @time gif_output = GifOutput(init;
           filename="forestfire.gif", tspan=1:200, fps=25,
           minval=DEAD, maxval=BURNING,
           scheme=ColorSchemes.rainbow,
           zerocolor=RGB24(0.0),
           font=FTFont("/usr/share/fonts/truetype/Cantarell-Regular.otf")
       )
  0.010344 seconds (26 allocations: 123.905 MiB)
```
This would also allow to do `using FreeTypeAbstraction; font = findfont("Cantarell")` once,
and feed that to all `font=` kwargs.

Also, later `autoconf` could return an `FTFont` instead of a `String`, saving one `findfont` call.

Two questions:
1) `savefig` is a bit faster (14s instead of 21s here), but there are still several `autoconf` calls.
For another PR, or would you rather treat all font issues at once ?

2) Two specific `TextConfig` tests are in `test/image.jl`.
If more are to be added, should they all be in a new `test/textconfig.pl` file ?
