### PR TITLE
Switch autoconf return type from String to FTFont

### DIFF
--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -40,16 +40,16 @@ function TextConfig(;
 end
 
 function autofont()
-    fonts = if Sys.islinux()
+    names = if Sys.islinux()
         ("cantarell", "sans-serif", "Bookman")
     else
         ("arial", "sans-serif") 
     end
-    for font in fonts
-        face = FreeTypeAbstraction.findfont(font)
+    for name in names
+        face = FreeTypeAbstraction.findfont(name)
         face isa Nothing || return face
     end
-    _nodefaultfonterror(fonts)
+    _nodefaultfonterror(names)
 end
 
 @noinline _fontnotstring(font) = throw(ArgumentError("font $font is not a String"))

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -47,7 +47,7 @@ function autofont()
     end
     for font in fonts
         face = FreeTypeAbstraction.findfont(font)
-        face isa Nothing || return font
+        face isa Nothing || return face
     end
     _nodefaultfonterror(fonts)
 end

--- a/test/textconfig.jl
+++ b/test/textconfig.jl
@@ -1,9 +1,9 @@
 using DynamicGrids, FreeTypeAbstraction, Test
 
 @testset "Fonts" begin
-	@test DynamicGrids.autofont() isa String
-	name = DynamicGrids.autofont()
-	face = FreeTypeAbstraction.findfont(name)
+	@test DynamicGrids.autofont() isa FreeTypeAbstraction.FTFont
+	face = DynamicGrids.autofont()
+	name = face.family_name
  	@testset "TextConfig accepts font as String" begin
 		@test name isa String
 		textconfig = TextConfig(; font=name)


### PR DESCRIPTION
With this PR, the value returned by `autoconf` can be used directly;
no need to pay the `findfont` price again.
For instance this almost halves the `savefig` time
(_from 20s to 12s, which is not good enough; to gain full speed another PR is almost ready, that will built upon this one_).

This is [internal stuff](https://github.com/cesaraustralia/DynamicGrids.jl/pull/202#issuecomment-1031661989), should not be breaking.