### PR TITLE
Cache default font

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -268,6 +268,7 @@ Greyscale
 
 ```@docs
 TextConfig
+DynamicGrids.set_default_font
 ```
 
 

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -8,7 +8,8 @@ Text configuration for printing timestep and grid name on the image.
 
 # Arguments / Keywords
 
-- `font`: A `FreeTypeAbstraction.FTFont`, or a `String` with the font name to look for. The `FTFont` may load more quickly.
+- `font`: A `FreeTypeAbstraction.FTFont`, or a `String` with the font name to look for.
+    The `FTFont` may load more quickly. See also [`set_default_font`](@ref).
 - `namepixels` and `timepixels`: the pixel size of the font.
 - `timepos` and `namepos`: tuples that set the label positions, in `Int` pixels.
 - `fcolor` and `bcolor`: the foreground and background colors, as `ARGB32`.
@@ -62,6 +63,8 @@ const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
 
 """
 Set default font.
+
+See also [`TextConfig`](@ref)
 
 # Examples
 Using `findfont` to get the font by name:

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -39,19 +39,6 @@ function TextConfig(;
     TextConfig(face, namepixels, namepos, timepixels, timepos, fcolor, bcolor)
 end
 
-function _autofont()
-    names = if Sys.islinux()
-        ("cantarell", "sans-serif", "Bookman")
-    else
-        ("arial", "sans-serif") 
-    end
-    for name in names
-        face = FreeTypeAbstraction.findfont(name)
-        face isa Nothing || return face
-    end
-    _nodefaultfonterror(names)
-end
-
 @noinline _fontnotstring(font) = throw(ArgumentError("font $font is not a String"))
 
 @noinline _fontnotfounderror(font) =
@@ -74,11 +61,23 @@ end
 const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
 
 function autofont()
-	if isassigned(_default_font_ref)
-		return _default_font_ref[]
-	else
-		return _default_font_ref[] = _autofont()
-	end
+    if isassigned(_default_font_ref)
+        return _default_font_ref[]
+    else
+        names = if Sys.islinux()
+            ("cantarell", "sans-serif", "Bookman")
+        else
+            ("arial", "sans-serif")
+        end
+        for name in names
+            face = FreeTypeAbstraction.findfont(name)
+            if face isa FreeTypeAbstraction.FTFont
+                _default_font_ref[] = face
+                return face
+            end
+        end
+        _nodefaultfonterror(names)
+    end
 end
 
 function set_default_font(font)

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -60,6 +60,10 @@ end
 # hence isassigned can tell whether the cache has been initialized
 const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
 
+function set_default_font(font)
+	_default_font_ref[] = font
+end
+
 function autofont()
     if isassigned(_default_font_ref)
         return _default_font_ref[]
@@ -72,16 +76,12 @@ function autofont()
         for name in names
             face = FreeTypeAbstraction.findfont(name)
             if face isa FreeTypeAbstraction.FTFont
-                _default_font_ref[] = face
+                set_default_font(face)
                 return face
             end
         end
         _nodefaultfonterror(names)
     end
-end
-
-function set_default_font(font)
-	_default_font_ref[] = font
 end
 
 # Render time `name` and `t` as text onto the image, following config settings.

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -39,7 +39,7 @@ function TextConfig(;
     TextConfig(face, namepixels, namepos, timepixels, timepos, fcolor, bcolor)
 end
 
-function autofont()
+function _autofont()
     names = if Sys.islinux()
         ("cantarell", "sans-serif", "Bookman")
     else
@@ -68,6 +68,22 @@ end
         name `String` with the keyword-argument `font`, for the `Output` or `ImageConfig`.
         """
     )
+
+# isbits(FreeTypeAbstraction.FTFont) == false,
+# hence isassigned can tell whether the cache has been initialized
+const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
+
+function autofont()
+	if isassigned(_default_font_ref)
+		return _default_font_ref[]
+	else
+		return _default_font_ref[] = _autofont()
+	end
+end
+
+function set_default_font(font)
+	_default_font_ref[] = font
+end
 
 # Render time `name` and `t` as text onto the image, following config settings.
 function _rendertime! end

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -35,12 +35,18 @@ function TextConfig(;
         face = FreeTypeAbstraction.findfont(font)
         face isa Nothing && _fontnotfounderror(font)
     else
-        _fontnotstring(font)
+        _fontwrongtype(font)
     end
     TextConfig(face, namepixels, namepos, timepixels, timepos, fcolor, bcolor)
 end
 
-@noinline _fontnotstring(font) = throw(ArgumentError("font $font is not a String"))
+@noinline _fontwrongtype(font) =
+    throw(ArgumentError(
+        """
+        font must be either a String or a FreeTypeAbstraction.FTFont,
+        got `$font` which is a `$(typeof(font))`.
+        """
+    ))
 
 @noinline _fontnotfounderror(font) =
     throw(ArgumentError(

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -124,29 +124,26 @@ _rendertime!(img, config::TextConfig, t::Nothing) = img
 _rendertime!(img, config::Nothing, t::Nothing) = img
 
 
-@noinline _fontwrongtype(font) =
-    throw(ArgumentError(
-        """
-        font must be either a String or a FreeTypeAbstraction.FTFont,
-        got `$font` which is a `$(typeof(font))`.
-        """
-    ))
+@noinline _fontwrongtype(font) = throw(ArgumentError(
+    """
+    font must be either a String or a FreeTypeAbstraction.FTFont,
+    got `$font` which is a `$(typeof(font))`.
+    """
+))
 
-@noinline _fontnotfounderror(font) =
-    throw(ArgumentError(
-        """
-        Font "$font" wasn't found in this system.
-        Specify an existing font with the `font` keyword,
-        or call DynamicGrids.set_default_font first,
-        or use `text=nothing` to display no text.
-        """
-    ))
+@noinline _fontnotfounderror(font) = throw(ArgumentError(
+    """
+    Font "$font" wasn't found in this system.
+    Specify an existing font with the `font` keyword,
+    or call DynamicGrids.set_default_font first,
+    or use `text=nothing` to display no text.
+    """
+))
 
-@noinline _nodefaultfonterror(font) =
-    error(
-        """
-        Your system does not contain any of the default fonts
-        $font.
-        Use DynamicGrids.set_default_font first.
-        """
-    )
+@noinline _nodefaultfonterror(font) = error(
+    """
+    Your system does not contain any of the default fonts
+    $font.
+    Use DynamicGrids.set_default_font first.
+    """
+)

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -45,8 +45,10 @@ end
 @noinline _fontnotfounderror(font) =
     throw(ArgumentError(
         """
-        Font "$font" wasn't be found in this system. Specify an existing font name 
-        with the `font` keyword, or use `text=nothing` to display no text."
+        Font "$font" wasn't found in this system.
+        Specify an existing font with the `font` keyword,
+        or call DynamicGrids.set_default_font first,
+        or use `text=nothing` to display no text.
         """
     ))
 @noinline _nodefaultfonterror(font) =

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -60,6 +60,27 @@ end
 # hence isassigned can tell whether the cache has been initialized
 const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
 
+"""
+Set default font.
+
+# Examples
+Using `findfont` to get the font by name:
+```julia
+using DynamicGrids
+using FreeTypeAbstraction: findfont
+
+font = findfont("Times")
+DynamicGrids.set_default_font(font)
+```
+Or giving the font path directly:
+```julia
+using DynamicGrids
+using FreeTypeAbstraction: FTFont
+
+font = FTFont("/usr/share/fonts/truetype/Adobe-Times-Regular.otb")
+DynamicGrids.set_default_font(font)
+```
+"""
 function set_default_font(font)
 	_default_font_ref[] = font
 end

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -52,8 +52,9 @@ end
 @noinline _nodefaultfonterror(font) =
     error(
         """
-        Your system does not contain the default font $font. Specify an existing font 
-        name `String` with the keyword-argument `font`, for the `Output` or `ImageConfig`.
+        Your system does not contain any of the default fonts
+        $font.
+        Use DynamicGrids.set_default_font first.
         """
     )
 

--- a/src/outputs/textconfig.jl
+++ b/src/outputs/textconfig.jl
@@ -40,32 +40,6 @@ function TextConfig(;
     TextConfig(face, namepixels, namepos, timepixels, timepos, fcolor, bcolor)
 end
 
-@noinline _fontwrongtype(font) =
-    throw(ArgumentError(
-        """
-        font must be either a String or a FreeTypeAbstraction.FTFont,
-        got `$font` which is a `$(typeof(font))`.
-        """
-    ))
-
-@noinline _fontnotfounderror(font) =
-    throw(ArgumentError(
-        """
-        Font "$font" wasn't found in this system.
-        Specify an existing font with the `font` keyword,
-        or call DynamicGrids.set_default_font first,
-        or use `text=nothing` to display no text.
-        """
-    ))
-@noinline _nodefaultfonterror(font) =
-    error(
-        """
-        Your system does not contain any of the default fonts
-        $font.
-        Use DynamicGrids.set_default_font first.
-        """
-    )
-
 # isbits(FreeTypeAbstraction.FTFont) == false,
 # hence isassigned can tell whether the cache has been initialized
 const _default_font_ref = Ref{FreeTypeAbstraction.FTFont}()
@@ -148,3 +122,31 @@ end
 _rendertime!(img, config::Nothing, t) = img
 _rendertime!(img, config::TextConfig, t::Nothing) = img
 _rendertime!(img, config::Nothing, t::Nothing) = img
+
+
+@noinline _fontwrongtype(font) =
+    throw(ArgumentError(
+        """
+        font must be either a String or a FreeTypeAbstraction.FTFont,
+        got `$font` which is a `$(typeof(font))`.
+        """
+    ))
+
+@noinline _fontnotfounderror(font) =
+    throw(ArgumentError(
+        """
+        Font "$font" wasn't found in this system.
+        Specify an existing font with the `font` keyword,
+        or call DynamicGrids.set_default_font first,
+        or use `text=nothing` to display no text.
+        """
+    ))
+
+@noinline _nodefaultfonterror(font) =
+    error(
+        """
+        Your system does not contain any of the default fonts
+        $font.
+        Use DynamicGrids.set_default_font first.
+        """
+    )


### PR DESCRIPTION
Caching default font is the last bit needed to accelerate `savegif` from 12s to 3.4s (fully fixes #194).
The timings now are
```julia
sim GifOutput:   3.543932 seconds (15.66 k allocations: 369.376 MiB, 2.02% gc time)
sim ArrayOutput:   0.486234 seconds (459 allocations: 2.530 MiB)
savegif:   3.139735 seconds (16.19 k allocations: 492.624 MiB, 0.02% gc time)
```

`set_default_font(FTFont(path))` _can_ be used to bypass any findfont call, if desired.
Please let me know if this is OK to `export` (I'd add a docstring then).